### PR TITLE
fix #Invalid|# error upon recipe importing for pico units (C/S/Pro)

### DIFF
--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -58,7 +58,9 @@ def import_zymatic_recipe():
         guid = data['guid']
         machine = next((uid for uid in active_brew_sessions if not active_brew_sessions[uid].is_pico), None)
         try:
-            r = requests.get('http://picobrew.com/API/SyncUSer?user={}&machine={}'.format(guid, machine))
+            sync_user_uri = 'http://picobrew.com/API/SyncUSer?user={}&machine={}'.format(guid, machine)
+            print('DEBUG: import_zymatic_recipe - {}'.format(sync_user_uri))
+            r = requests.get(sync_user_uri)
             recipes = r.text.strip()
         except:
             pass
@@ -165,7 +167,9 @@ def import_pico_recipe():
         rfid = data['rfid']
         uid = next((uid for uid in active_brew_sessions if active_brew_sessions[uid].is_pico), None)
         try:
-            r = requests.get('http://picobrew.com/API/pico/getRecipe?uid={}&rfid={}&ibu=-1&abv=-1.0'.format(uid, rfid))
+            get_recipes_uri = 'http://picobrew.com/API/pico/getRecipe?uid={}&rfid={}&ibu=-1&abv=-1.0'.format(uid, rfid)
+            print('DEBUG: import_pico_recipe - {}'.format(get_recipes_uri))
+            r = requests.get(get_recipes_uri)
             recipe = r.text.strip()
         except:
             pass

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -38,6 +38,7 @@ def load_brew_session(file):
         'name': name,
         'uid': info[1],
         'session': info[2],
+        'is_pico': len(info[1]) == 32,
         'type': session_type,
         'alias': alias,
         'data': json_data,
@@ -186,6 +187,6 @@ def restore_active_sessions():
             session.id = -1                             # session id (interger)
             # session.recovery = ''                     # find last step name
             # session.remaining_time = None
-            # session.is_pico = True
+            session.is_pico = brew_session['is_pico']
             session.data = brew_session['data']
             active_brew_sessions[brew_session['uid']] = session


### PR DESCRIPTION
Zymatic and ZSeries upon initializing from brew sessions will be identified as `.is_pico` units. This will cause the "first" to be loaded to be used for fetching the picopak recipe.

I believe all UIDs of C/S/Pro units are 32 characters (ie uuids) so should be safe enough to assume that to be true.

I'm uncertain how Zymatic UserSync and ZSeries interact, but will test those flows as well.