### PR TITLE
fix dirty session counter and last session type in zstate response

### DIFF
--- a/app/main/model.py
+++ b/app/main/model.py
@@ -31,6 +31,7 @@ PICO_LOCATION = {
     'Adjunct3': '6',
     'Adjunct4': '5',
 }
+
 PICO_SESSION = {
     0: 'Brewing',
     1: 'Deep Clean',

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -245,6 +245,9 @@ zseries_recipes = []
 
 
 def initialize_data():
+    global pico_recipes, zymatic_recipes, zseries_recipes
+    global brew_sessions
+
     # Read initial recipe list on load
     pico_recipes = load_pico_recipes()
     zymatic_recipes = load_zymatic_recipes()

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -7,7 +7,10 @@ from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
 from . import main
+from .config import brew_active_sessions_path
+from .model import PicoBrewSession, PICO_SESSION
 from .routes_frontend import get_pico_recipes
+from .session_parser import active_brew_sessions
 from .. import *
 
 arg_parser = FlaskParser()
@@ -208,6 +211,6 @@ def create_new_session(uid, sesId, sesType):
         active_brew_sessions[uid].name = PICO_SESSION[sesType]
     else:
         active_brew_sessions[uid].name = 'Unknown Session ({})'.format(sesType)
-    active_brew_sessions[uid].filepath = Path(BREW_ACTIVE_PATH).joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, sesId, active_brew_sessions[uid].name.replace(' ', '_')))
+    active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, sesId, active_brew_sessions[uid].name.replace(' ', '_')))
     active_brew_sessions[uid].file = open(active_brew_sessions[uid].filepath, 'w')
     active_brew_sessions[uid].file.write('[\n')

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -6,6 +6,9 @@ from flask import *
 from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
+from .config import ferm_active_sessions_path, ferm_archive_sessions_path
+from .model import PicoFermSession
+from .session_parser import active_ferm_sessions
 from . import main
 from .. import *
 
@@ -96,6 +99,6 @@ def create_new_session(uid):
         active_ferm_sessions[uid] = PicoFermSession()
     active_ferm_sessions[uid].uninit = False
     active_ferm_sessions[uid].start_time = datetime.now()  # Not now, but X samples * 60*RATE sec ago
-    active_ferm_sessions[uid].filepath = Path(FERM_ACTIVE_PATH).joinpath('{0}#{1}.json'.format(active_ferm_sessions[uid].start_time.strftime('%Y%m%d_%H%M%S'), uid))
+    active_ferm_sessions[uid].filepath = ferm_active_sessions_path().joinpath('{0}#{1}.json'.format(active_ferm_sessions[uid].start_time.strftime('%Y%m%d_%H%M%S'), uid))
     active_ferm_sessions[uid].file = open(active_ferm_sessions[uid].filepath, 'w')
     active_ferm_sessions[uid].file.write('[\n')

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -180,7 +180,7 @@ def dirty_sessions_since_clean(uid):
     brew_sessions = get_archived_sessions_by_machine(uid)
     post_clean_sessions = []
     clean_found = False
-    for s in reversed(brew_sessions):
+    for s in brew_sessions:
         session_type = SessionType(s['type'])
         if (session_type == SessionType.CLEAN):
             clean_found = True
@@ -197,7 +197,7 @@ def last_session_type(uid):
     if len(brew_sessions) == 0:
         return SessionType.CLEAN
     else:
-        last_session = brew_sessions[len(brew_sessions) - 1]
+        last_session = brew_sessions[0]
         # just assume last session was a rinse session (session after a brew)
         session_type = SessionType(last_session['type']) if last_session['type'] is not None else SessionType.RINSE
         return session_type

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -7,7 +7,10 @@ from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
 from . import main
+from .config import brew_active_sessions_path, brew_archive_sessions_path
+from .model import PicoBrewSession
 from .routes_frontend import get_zseries_recipes, load_brew_sessions
+from .session_parser import active_brew_sessions
 from .. import *
 from enum import Enum
 from random import seed
@@ -305,7 +308,7 @@ def create_session(token, body):
     active_brew_sessions[uid].created_at = datetime.utcnow().isoformat()
     active_brew_sessions[uid].name = recipe.name if recipe else body['Name']
     active_brew_sessions[uid].type = body['SessionType']
-    active_brew_sessions[uid].filepath = Path(BREW_ACTIVE_PATH).joinpath('{0}#{1}#{2}#{3}#{4}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, active_brew_sessions[uid].name.replace(' ', '_'), active_brew_sessions[uid].type))
+    active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath('{0}#{1}#{2}#{3}#{4}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, active_brew_sessions[uid].name.replace(' ', '_'), active_brew_sessions[uid].type))
 
     current_app.logger.debug('ZSeries - session file created {}'.format(active_brew_sessions[uid].filepath))
 

--- a/app/main/routes_zymatic_api.py
+++ b/app/main/routes_zymatic_api.py
@@ -7,7 +7,10 @@ from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
 from . import main
+from .config import brew_active_sessions_path
+from .model import PicoBrewSession
 from .routes_frontend import get_zymatic_recipes
+from .session_parser import active_brew_sessions
 from .. import *
 
 arg_parser = FlaskParser()
@@ -127,7 +130,7 @@ def process_log_session(args):
             active_brew_sessions[uid] = PicoBrewSession()
         active_brew_sessions[uid].session = uuid.uuid4().hex[:32]
         active_brew_sessions[uid].name = get_recipe_name_by_id(args['recipe'])
-        active_brew_sessions[uid].filepath = Path(BREW_ACTIVE_PATH).joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, active_brew_sessions[uid].name.replace(' ', '_')))
+        active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, active_brew_sessions[uid].name.replace(' ', '_')))
         active_brew_sessions[uid].file = open(active_brew_sessions[uid].filepath, 'w')
         active_brew_sessions[uid].file.write('[\n')
         active_brew_sessions[uid].file.flush()

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -2,7 +2,7 @@ import json, uuid
 from pathlib import Path
 
 from .config import brew_active_sessions_path
-from .model import PicoBrewSession, PicoFermSession
+from .model import PicoBrewSession
 from .. import *
 
 active_brew_sessions = {}
@@ -162,16 +162,14 @@ def get_ferm_graph_data(chart_id, voltage, session_data):
 
 def restore_active_sessions():
     # initialize active sessions during start up
-
-    # not defined... circular dependency????
     if active_brew_sessions == {}:
-        print('DEBUG: load_active_brew_sessions() fetching abandoned server active sessions')
+        print('DEBUG: restore_active_sessions() fetching abandoned server active sessions')
 
         active_brew_session_files = list(brew_active_sessions_path().glob("*.json"))
         for file in active_brew_session_files:
-            # print('DEBUG: load_active_brew_sessions() found {} as an active session'.format(file))
+            # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             brew_session = load_brew_session(file)
-            # print('DEBUG: load_active_brew_sessions() {}'.format(brew_session))
+            # print('DEBUG: restore_active_sessions() {}'.format(brew_session))
             if brew_session['uid'] not in active_brew_sessions:
                 active_brew_sessions[brew_session['uid']] = []
 


### PR DESCRIPTION
`get_archived_sessions_by_machine(uid)` is descending (latest first; oldest last) so flip the logic for querying the archive sessions for a machine to determine last session type and if the machine has had 3 "dirty" (aka beer, coffee, or sous vide) sessions