### PR TITLE
Nginx with http and https entries to support the different devices types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Python >= 3.6.9
 #### Setup/Run
 Clone this repo, then run  
 `sudo pip3 install -r requirements.txt` on *nix or `pip3 install -r requirements.txt` as an Administrator in windows  
-`sudo python3 server.py` on *nix or `python3 server.py` as an Administrator in windows
+`sudo python3 server.py` on *nix or `python3 server.py` as an Administrator in windows (default host interface is `0.0.0.0` and port `80`, but these can be specified via command-line arguments like so `python3 server.py <interface> <port>`)
 
 ## Manual Recipe Editing
 The table for adding/removing/editing recipe steps has several validation checks in it, but there is always the possiblity of ruining your Pico.  

--- a/server.py
+++ b/server.py
@@ -1,6 +1,19 @@
 from app import create_app, socketio
+import sys
+
+# defaults
+PORT=80
+HOST='0.0.0.0'
+
+if len(sys.argv) != 1 and len(sys.argv) != 3:
+    print("Usage: python {} OR python {} <HostName> <PortNumber>".format(sys.argv[0], sys.argv[0]))
+    sys.exit()
+
+if len(sys.argv) == 3:
+    HOST=sys.argv[1]
+    PORT=sys.argv[2]
 
 app = create_app(debug=True)
 
 if __name__ == '__main__':
-    socketio.run(app, host='0.0.0.0', port=80)
+    socketio.run(app, host=HOST, port=PORT)


### PR DESCRIPTION
In our raspberrypi scripts we need to install nginx due to python only running either in ssl or non-ssl mode. This way the python server is simple (non-ssl) and there is a reverse proxy in front terminating the ssl connection and re-establishing a non-ssl connection to the python server.

This setup requires nginx to run on port 80 and 443 so I'm added command line arguments that can control what interface and port the flask app is running on with details updated in the README.md (all backwards compatible with defaults to `0.0.0.0:80` as previously used).