### PR TITLE
Various fixes for socketio and session graphing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,11 @@
-from flask import *
+from flask import Flask
 from flask_cors import CORS
 from flask_socketio import SocketIO
 from pathlib import Path
 import yaml
 import os
 
-from .main.model import PicoFermSession, PicoBrewSession
-from .main.config import brew_active_sessions_path
-from .main.session_parser import restore_active_sessions, active_brew_sessions, active_ferm_sessions
-from .main.routes_frontend import initialize_data
+    
 
 BASE_PATH = Path(__file__).parents[1]
 
@@ -22,11 +19,18 @@ def create_app(debug=False):
     app = Flask(__name__)
     CORS(app)
 
+    socketio.init_app(app)
+
+    # these imports required to be after socketio initialization
+    from .main.config import brew_active_sessions_path
+    from .main.model import PicoFermSession, PicoBrewSession
+    from .main.routes_frontend import initialize_data
+    from .main.session_parser import restore_active_sessions, active_brew_sessions, active_ferm_sessions
+
     from .main import main as main_blueprint
 
     # ----- Routes ----------
     app.register_blueprint(main_blueprint)
-    socketio.init_app(app)
 
     cfg_file = BASE_PATH.joinpath('config.yaml')
     with open(cfg_file, 'r') as f:
@@ -36,7 +40,7 @@ def create_app(debug=False):
         SECRET_KEY='bosco',
         CORS_HEADERS='Content-Type',
         RECIPES_PATH=BASE_PATH.joinpath('app/recipes'),
-        SESSIONS_PATH=BASE_PATH.joinpath('app/sessions'),
+        SESSIONS_PATH=BASE_PATH.joinpath('app/sessions')
     )
 
     with app.app_context():

--- a/app/main/recipe_parser.py
+++ b/app/main/recipe_parser.py
@@ -2,7 +2,6 @@ import json, uuid
 
 from .config import zymatic_recipe_path, zseries_recipe_path, pico_recipe_path
 from .model import PICO_LOCATION, ZYMATIC_LOCATION, ZSERIES_LOCATION
-from .. import *
 
 
 class ZymaticRecipeStep():

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -1,7 +1,7 @@
 import json
 import requests
 import uuid
-from flask import *
+from flask import render_template, request
 from pathlib import Path
 
 from . import main

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -2,16 +2,17 @@ import json, uuid
 from datetime import datetime
 from pathlib import Path
 from time import mktime
-from flask import *
+from flask import current_app
 from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
+
+from .. import socketio
 from . import main
 from .config import brew_active_sessions_path
 from .model import PicoBrewSession, PICO_SESSION
 from .routes_frontend import get_pico_recipes
 from .session_parser import active_brew_sessions
-from .. import *
 
 arg_parser = FlaskParser()
 

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -2,15 +2,16 @@ import json, uuid
 from datetime import datetime
 from pathlib import Path
 from time import mktime
-from flask import *
+from flask import current_app, request
 from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
+
+from . import main
+from .. import socketio
 from .config import ferm_active_sessions_path, ferm_archive_sessions_path
 from .model import PicoFermSession
 from .session_parser import active_ferm_sessions
-from . import main
-from .. import *
 
 arg_parser = FlaskParser()
 

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -2,19 +2,19 @@ import json, uuid, os
 from datetime import datetime
 from pathlib import Path
 from time import mktime
-from flask import *
+from flask import current_app, request
 from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
+from enum import Enum
+from random import seed, randint
+
+from .. import socketio
 from . import main
 from .config import brew_active_sessions_path, brew_archive_sessions_path
 from .model import PicoBrewSession
 from .routes_frontend import get_zseries_recipes, load_brew_sessions
 from .session_parser import active_brew_sessions
-from .. import *
-from enum import Enum
-from random import seed
-from random import randint
 
 
 arg_parser = FlaskParser()

--- a/app/main/routes_zymatic_api.py
+++ b/app/main/routes_zymatic_api.py
@@ -2,16 +2,18 @@ import json, uuid, os
 from datetime import datetime
 from pathlib import Path
 from time import mktime
-from flask import *
+from flask import current_app, request
 from flask_socketio import emit
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
+
+from .. import socketio
 from . import main
 from .config import brew_active_sessions_path
 from .model import PicoBrewSession
 from .routes_frontend import get_zymatic_recipes
 from .session_parser import active_brew_sessions
-from .. import *
+
 
 arg_parser = FlaskParser()
 events = {}

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -184,7 +184,10 @@ def restore_active_sessions():
             session.type = brew_session['type']
             session.session = brew_session['session']   # session guid
             session.id = -1                             # session id (interger)
-            session.recovery = brew_session['recovery'] # find last step name
+            
+            if 'recovery' in brew_session:
+                session.recovery = brew_session['recovery'] # find last step name
+            
             # session.remaining_time = None
             session.is_pico = brew_session['is_pico']
             session.data = brew_session['data']

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from .config import brew_active_sessions_path
 from .model import PicoBrewSession
-from .. import *
 
 active_brew_sessions = {}
 active_ferm_sessions = {}
@@ -44,6 +43,8 @@ def load_brew_session(file):
         'data': json_data,
         'graph': get_brew_graph_data(chart_id, name, step, json_data)
     }
+    if len(json_data) > 0:
+        session['recovery'] = json_data[-1]['recovery']
     return (session)
 
 
@@ -183,7 +184,7 @@ def restore_active_sessions():
             session.type = brew_session['type']
             session.session = brew_session['session']   # session guid
             session.id = -1                             # session id (interger)
-            # session.recovery = ''                     # find last step name
+            session.recovery = brew_session['recovery'] # find last step name
             # session.remaining_time = None
             session.is_pico = brew_session['is_pico']
             session.data = brew_session['data']

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -9,7 +9,7 @@ Highcharts.chart(graph_data.chart_id, {
     events: {
       load: function () {
         var self = this
-        var socket = io.connect('http://' + document.domain + ':' + location.port)
+        var socket = io.connect('//' + document.domain + ':' + location.port)
         var event_name = 'brew_session_update|' + graph_data.chart_id
         socket.on(event_name, function (event)
         {

--- a/app/static/js/ferm_graph_socketio.js
+++ b/app/static/js/ferm_graph_socketio.js
@@ -9,7 +9,7 @@ chart: {
   events: {
     load: function () {
       var self = this
-      var socket = io.connect('http://' + document.domain + ':' + location.port)
+      var socket = io.connect('//' + document.domain + ':' + location.port)
       var event_name = 'ferm_session_update|' + graph_data.chart_id
       socket.on(event_name, function (event)
       {

--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ if len(sys.argv) != 1 and len(sys.argv) != 3:
 
 if len(sys.argv) == 3:
     HOST=sys.argv[1]
-    PORT=sys.argv[2]
+    PORT=int(sys.argv[2])
 
 app = create_app(debug=True)
 


### PR DESCRIPTION
Here are a number of cleanups and fixes with regard to session graphing and socketio usage now that we are acting as a domain on the local network with raspberrypi via nginx.

- clean up and order imports (circular dependency of __init__.py for resolving global `socketio`)
- use relative scheme `//<hostname>` for clientside socketio (https -> https; http -> http) as modern browsers will prevent "downgrading" of the security scheme within a web session
- fix event logic for recovered active session events (recovered sessions weren't storing a top level `session['recovery']` which would produce duplicated event lines in zseries reported session data
- add websocket/ws nginx route
- include `www.picobrew` and `.picobrew` in nginx server_name configuration

Kinda resolves https://github.com/chiefwigms/picobrew_pico/issues/26 by preventing the situation from occuring... however we still could receive a file with the following content which could trigger this error again. Simply deleting the session would resolve it, but making our session file writing more robust (ie. always writing a fully structured JSON file for instance with session name, id, device, etc would help to prevent that as well  outside of terminating the server in the middle of writing the file):

```

]
```