### PR TITLE
fix dict access of args in firmware check

### DIFF
--- a/app/main/routes_picostill_api.py
+++ b/app/main/routes_picostill_api.py
@@ -41,9 +41,9 @@ picostill_check_firmware_args = {
     'uid': fields.Str(required=True),       # 32 character alpha-numeric serial number
     'version': fields.Str(required=True),   # Current firmware version - i.e. 0.0.30
 }
-@main.route('/API/PicoStill/getFirmwareAddress')
+@main.route('/API/PicoStill/getFirmwareAddress', methods=['GET'])
 @use_args(picostill_check_firmware_args, location='querystring')
 def process_picostill_check_firmware(args):
-    if args.version != latest_firmware['version']:
+    if args['version'] != latest_firmware['version']:
         return '#{}#'.format(latest_firmware['source'])
     return '#F#'


### PR DESCRIPTION
This fix was staged on a different branch thus never got pushed with https://github.com/chiefwigms/picobrew_pico/pull/49

Resolves the following error in running this code.

```
File ".../picobrew_pico/app/main/routes_picostill_api.py", line 47, in process_picostill_check_firmware
    if args.version != latest_firmware['version']:
AttributeError: 'dict' object has no attribute 'version'
```

Working code with couple of requests tested against it.

```
python3 server.py
WebSocket transport not available. Install eventlet or gevent and gevent-websocket for improved performance.
 * Serving Flask app "app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://0.0.0.0:80/ (Press CTRL+C to quit)
127.0.0.1 - - [15/Jul/2020 06:53:59] "GET /API/PicoStill/getFirmwareAddress?uid=1234&version=0.0.30 HTTP/1.1" 200 -
127.0.0.1 - - [15/Jul/2020 06:54:04] "GET /API/PicoStill/getFirmwareAddress?uid=1234&version=0.0.29 HTTP/1.1" 200 -
```