### PR TITLE
Support Configuration Overridable Minimum Firmware Versions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,7 @@ def create_app(debug=False):
     socketio.init_app(app)
 
     # these imports required to be after socketio initialization
+    from .main.config import MachineType
     from .main.model import PicoFermSession, PicoBrewSession
     from .main.routes_frontend import initialize_data
     from .main.session_parser import restore_active_sessions, active_brew_sessions, active_ferm_sessions
@@ -39,7 +40,8 @@ def create_app(debug=False):
         BASE_PATH=BASE_PATH,
         RECIPES_PATH=BASE_PATH.joinpath('app/recipes'),
         SESSIONS_PATH=BASE_PATH.joinpath('app/sessions'),
-        FIRMWARE_PATH=BASE_PATH.joinpath('app/firmware')
+        FIRMWARE_PATH=BASE_PATH.joinpath('app/firmware'),
+        SERVER_CONFIG=server_cfg
     )
 
     with app.app_context():
@@ -47,18 +49,18 @@ def create_app(debug=False):
         initialize_data()
 
     if 'aliases' in server_cfg:
-        machine_types = ["ZSeries", "Zymatic", "PicoBrew", "PicoFerm"]
+        machine_types = [MachineType.ZSERIES, MachineType.ZYMATIC, MachineType.PICOBREW, MachineType.PICOFERM, MachineType.PICOSTILL]
         for mtype in machine_types:
             aliases = server_cfg['aliases']
             if mtype in aliases and aliases[mtype] is not None:
                 for uid in aliases[mtype]:
                     if uid in aliases[mtype] and uid != "uid":
-                        if mtype == "PicoFerm":
+                        if mtype == MachineType.PicoFerm:
                             active_ferm_sessions[uid] = PicoFermSession()
                             active_ferm_sessions[uid].alias = aliases[mtype][uid]
                         else:
                             active_brew_sessions[uid] = PicoBrewSession()
                             active_brew_sessions[uid].alias = aliases[mtype][uid]
-                            active_brew_sessions[uid].is_pico = True if mtype == "PicoBrew" else False
+                            active_brew_sessions[uid].is_pico = True if mtype == MachineType.PICOBREW else False
 
     return app

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -1,4 +1,18 @@
+from enum import Enum
 from flask import current_app
+
+
+class MachineType(str, Enum):
+    PICOBREW = 'PicoBrew'
+    PICOFERM = 'PicoFerm'
+    PICOSTILL = 'PicoStill'
+    ZSERIES = 'ZSeries'
+    ZYMATIC = 'Zymatic'
+
+
+# server config
+def server_config():
+    return current_app.config['SERVER_CONFIG']
 
 
 # base path

--- a/app/main/firmware.py
+++ b/app/main/firmware.py
@@ -1,0 +1,28 @@
+from .config import MachineType, server_config
+from distutils.version import LooseVersion, StrictVersion
+
+def firmware_filename(device: MachineType, version: str):
+    if (device == MachineType.PICOBREW):
+        return "pico_{}.bin".format(version.replace(".", "_"))
+    return "{}_{}.bin".format(device.lower(), version.replace(".", "_"))
+
+
+def firmware_upgrade_required(device: MachineType, version: str):
+    return LooseVersion(version) < LooseVersion(minimum_firmware(device))
+
+
+def minimum_firmware(device: MachineType):
+    default_firmware = {
+        MachineType.ZSERIES: '0.0.116',
+        MachineType.PICOBREW: '0.1.34',
+        MachineType.PICOSTILL: '0.0.30'
+    }
+
+    if device not in default_firmware:
+        raise Exception('invalid device type {}'.format(device))
+
+    if 'firmware' in server_config():
+        firmware = server_config()['firmware']
+        return firmware.get(device, default_firmware[device])
+    else:
+        return default_firmware[device]

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -7,17 +7,14 @@ from webargs.flaskparser import use_args, FlaskParser
 
 from .. import socketio
 from . import main
-from .config import brew_active_sessions_path, pico_firmware_path
+from .config import MachineType, brew_active_sessions_path, pico_firmware_path
+from .firmware import firmware_filename, minimum_firmware, firmware_upgrade_required
 from .model import PicoBrewSession, PICO_SESSION
 from .routes_frontend import get_pico_recipes
 from .session_parser import active_brew_sessions
 
 arg_parser = FlaskParser()
 
-latest_firmware = {
-    "version": "0.1.34",
-    "filepath": "pico_0_1_34.bin"
-}
 
 # Register: /API/pico/register?uid={UID}
 # Response: '#{0}#\r\n' where {0} : T = Registered, F = Not Registered
@@ -51,6 +48,8 @@ check_firmware_args = {
 @main.route('/API/pico/checkFirmware')
 @use_args(check_firmware_args, location='querystring')
 def process_check_firmware(args):
+    if firmware_upgrade_required(MachineType.PICOBREW, args['version']):
+        return '#T#'
     return '#F#'
 
 
@@ -62,8 +61,8 @@ get_firmware_args = {
 @main.route('/API/pico/getFirmware')
 @use_args(get_firmware_args, location='querystring')
 def process_get_firmware(args):
-    # TODO setup config to select firmware version, add latest symlink
-    f = open(pico_firmware_path().joinpath(latest_firmware['filepath']))
+    filename = firmware_filename(MachineType.PICOBREW, minimum_firmware(MachineType.PICOBREW))
+    f = open(pico_firmware_path().joinpath(filename))
     fw = f.read()
     f.close()
     return '{}'.format(fw)

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -32,6 +32,7 @@ check_ferm_firmware_args = {
 @main.route('/API/PicoFerm/checkFirmware')
 @use_args(check_ferm_firmware_args, location='querystring')
 def process_check_ferm_firmware(args):
+    # TODO download the firmware for a picoferm and support minimum firmware versions
     return '#0#'
 
 

--- a/app/main/routes_picostill_api.py
+++ b/app/main/routes_picostill_api.py
@@ -11,6 +11,7 @@ from random import seed, randint
 from .. import socketio
 from . import main
 from .config import picostill_firmware_path
+from .firmware import MachineType, firmware_filename, firmware_upgrade_required, minimum_firmware
 from .model import PicoBrewSession
 from .routes_frontend import get_zseries_recipes, load_brew_sessions
 from .session_parser import active_brew_sessions
@@ -20,11 +21,6 @@ arg_parser = FlaskParser()
 seed(1)
 
 events = {}
-
-latest_firmware = {
-    "version": "0.0.30",
-    "source": "https://picobrew.com/firmware/picostill/picostill_0_0_30.bin"
-}
 
 
 # Get Firmware: /firmware/picostill/<version>
@@ -44,6 +40,7 @@ picostill_check_firmware_args = {
 @main.route('/API/PicoStill/getFirmwareAddress', methods=['GET'])
 @use_args(picostill_check_firmware_args, location='querystring')
 def process_picostill_check_firmware(args):
-    if args['version'] != latest_firmware['version']:
-        return '#{}#'.format(latest_firmware['source'])
+    if firmware_upgrade_required(MachineType.PICOSTILL, args['version']):
+        filename = firmware_filename(MachineType.PICOSTILL, minimum_firmware(MachineType.PICOSTILL))
+        return '#https://picobrew.com/firmware/picostill/{}#'.format(filename)
     return '#F#'

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,4 @@ firmware: # specify minimum firmware versions to push to your devices (binaries 
   # ZSeries: 0.0.119
   # PicoBrew: 0.1.34
   # PicoStill: 0.0.35
+  

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,10 @@ aliases: # ProductID (Found under 'Settings'->'Equipment' on www.picobrew.com) m
     #ProductID : Nickname
   PicoFerm:
     #ProductID : Nickname
+  PicoStill:
+    #ProductID : Nickname
+
+firmware: # specify minimum firmware versions to push to your devices (binaries found in ./app/firmware/<device_type>/)
+  # ZSeries: 0.0.119
+  # PicoBrew: 0.1.34
+  # PicoStill: 0.0.35


### PR DESCRIPTION
This has been something I've been working on to allow folks to either force their own firmware, or another version  of firmware that is included in with the server. 

Configuration file would require a new block (see example below or in comments in config.yaml for syntax).

```
firmware: # specify minimum firmware versions to push to your devices (binaries found in ./app/firmware/<device_type>/)
  ZSeries: 0.0.119
  PicoBrew: 0.1.34
  PicoStill: 0.0.35
```

This way users can choose if they want to run unreleased firmware versions without having to modify code to get them. Several of us early beta testers were side loading unreleased firmware or had devices that were in a "beta" release group to get early releases from Picobrew for testing before a full rollout was made available to all Picobrew users of the various device lines.