### PR TITLE
parrot the server known alias to the ZState request

### DIFF
--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -228,7 +228,7 @@ def resumable_session_id(uid):
 def zseries_alias(uid):
     if uid not in active_brew_sessions:
         return "ZSeries"
-    return active_brew_sessions[uid].alias
+    return active_brew_sessions[uid].alias or "ZSeries"
 
 
 def create_or_close_session(args):

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -174,7 +174,7 @@ def process_zstate(args):
     uid = request.args['token']
 
     returnVal = {
-        "Alias": "ZSeries",
+        "Alias": zseries_alias(uid),
         "BoilerType": json['BoilerType'],       # TODO sometimes machine loses boilertype, need to resync with known state
         "IsRegistered": True,                   # likely we don't care about registration with BYOS
         "IsUpdated": False if update_required else True,
@@ -223,6 +223,12 @@ def resumable_session_id(uid):
     if uid not in active_brew_sessions:
         return -1
     return active_brew_sessions[uid].id
+
+
+def zseries_alias(uid):
+    if uid not in active_brew_sessions:
+        return "ZSeries"
+    return active_brew_sessions[uid].alias
 
 
 def create_or_close_session(args):


### PR DESCRIPTION
resolves issue reported in https://github.com/chiefwigms/picobrew_pico/issues/57 where the server alias isn't sent to the device for showing locally on the screen of the Z