### PR TITLE
add api support for using pico c with picostill

### DIFF
--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -194,6 +194,36 @@ def process_log(args):
     return '\r\n\r\n'
 
 
+# Pico with Picostill requests
+pico_still_args = {
+    'picoUid': fields.Str(required=True),       # 32 character alpha-numeric serial number
+    'picoStillUid': fields.Str(required=True),   # 12 character alpha-numeric serial number
+}
+
+# Can Use Still: /API/pico/canUsePicoStill?picoUid={UID}&picoStillUid={UID}
+#    Response: '#{0}#\r\n' where {0} : T (or F?)
+@main.route('/API/pico/canUsePicoStill')
+@use_args(pico_still_args, location='querystring')
+def process_can_use_pico_still(args):
+    return '#T#\r\n'
+
+# Has cleaned still: /API/pico/hasCleanedAck?picoUid={UID}&picoStillUid={UID}
+#    Response: '#{0}#\r\n' where {0} : T (or F?)
+@main.route('/API/pico/hasCleanedAck')
+@use_args(pico_still_args, location='querystring')
+def process_is_cleaned(args):
+    return '#T#\r\n'
+
+# Set cleaned still: /API/pico/setCleanedAck?picoUid={UID}&picoStillUid={UID}
+#    Response: '#T#\r\n'
+# Allows a user override of hasCleanedAck if unsuccessful
+@main.route('/API/pico/setCleanedAck')
+@use_args(pico_still_args, location='querystring')
+def process_set_cleaned(args):
+    return '#T#\r\n'
+
+
+
 # -------- Utility --------
 def get_recipe_by_id(recipe_id):
     recipe = next((r for r in get_pico_recipes() if r.id == recipe_id), None)


### PR DESCRIPTION
Adds API endpoints necessary for enabling the PicoStill to work with a Pico C.

Note that with the 'hasCleanedAck' always returning true, the 'setCleanedAck' endpoint is likely unnecessary, but I've added it for completeness.

Also note that with these additions I was able to successfully use all Pico C functions that I am aware of. 