### PR TITLE
fix StillUid -> StillUID for session create and close

### DIFF
--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -553,7 +553,7 @@ def close_session(uid, session_id, body):
         "SecondsRemaining": 0,
         "SessionLogs": [],
         "SessionType": body['SessionType'],
-        "StillUID": body['StillUid'],
+        "StillUID": body['StillUID'],
         "StillVer": body['StillVer'],
         "ZProgramId": body['ZProgramId'],
         "ZSeriesID": uid


### PR DESCRIPTION
Fixes the error that occurs on session close when user exits still session, guess yesterday I missed that there was a close session request in the flood of 6 hours of update session logs.

The session logging failures during a PicoStill session will not disrupt the session itself and things continue on the devices as normal operation.

```
Jul 23 15:48:10 picobrew-logger rc.local[8803]: [2020-07-23 15:48:10,340] ERROR in app: Exception on /Vendors/input.csht
Jul 23 15:48:10 picobrew-logger rc.local[8803]: Traceback (most recent call last):
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2447,
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     response = self.full_dispatch_request()
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1952,
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     rv = self.handle_user_exception(e)
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask_cors/extension.py",
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     return cors_after_request(app.make_response(f(*args, **kwargs)))
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1821,
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     reraise(exc_type, exc_value, tb)
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 3
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     raise value
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1950,
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     rv = self.dispatch_request()
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1936,
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     return self.view_functions[rule.endpoint](**req.view_args)
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/usr/local/lib/python3.7/dist-packages/webargs/core.py", line 36
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     return func(*args, **kwargs)
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/picobrew_pico/app/main/routes_zseries_api.py", line 121, in pro
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     return create_or_close_session(request)
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/picobrew_pico/app/main/routes_zseries_api.py", line 241, in cre
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     return close_session(request.args.get('token'), session_id, request.
Jul 23 15:48:10 picobrew-logger rc.local[8803]:   File "/picobrew_pico/app/main/routes_zseries_api.py", line 556, in clo
Jul 23 15:48:10 picobrew-logger rc.local[8803]:     "StillUID": body['StillUid'],
Jul 23 15:48:10 picobrew-logger rc.local[8803]: KeyError: 'StillUid'
Jul 23 15:48:10 picobrew-logger rc.local[8803]: 127.0.0.1 - - [23/Jul/2020 15:48:10] "PUT /Vendors/input.cshtml?type=ZSession&token=240ac41d9ae4&id=1 HTTP/1.1" 500 -
```