### PR TITLE
Setup GitHub Action docker-push

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -18,4 +18,5 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: cheifwigms/picobrew_pico
-        tags: latest,$(git rev-parse --short "$GITHUB_SHA")
+        add_git_labels: true
+        tags: latest

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -17,6 +17,5 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: cheifwigms/picobrew_pico
-        add_git_labels: true
+        repository: chiefwigms/picobrew_pico
         tags: latest

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,21 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: cheifwigms/picobrew_pico
+        tags: latest,$(git rev-parse --short "$GITHUB_SHA")


### PR DESCRIPTION
Requires `chiefwigms/picobrew_pico` to have docker hub username and password secrets setup with permission to push to https://hub.docker.com/r/chiefwigms/picobrew_pico. I tried my access token and for some reason this these aren't allowed to programmatically push to docker whereas my username:password is.