### PR TITLE
Create New /about and /setup Experiences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # python files
 **/__pycache__
 

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -330,7 +330,7 @@ def setup():
             if 'bssid' in wireless and wireless['bssid']:
                 bssid = wireless['bssid']
                 subprocess.check_output(
-                    """sed -i -e 's/bssid=.*/bssid="{}"/' {}""".format(bssid, wpa_files), shell=True)
+                    """sed -i -e 's/bssid=.*/bssid={}/' {}""".format(bssid, wpa_files), shell=True)
                 
             # set credentials (if set by user) in wpa_supplicant files
             if 'password' in wireless and wireless['password']:
@@ -338,9 +338,17 @@ def setup():
                 subprocess.check_output(
                     """sed -i -e 's/psk=.*/psk="{}"/' {}""".format(psk, wpa_files), shell=True)
             
-            # restart wireless services
-            subprocess.check_output('systemctl status wpa_supplicant@wlan0.service', shell=True)
+            def restart_wireless():
+                import subprocess
+                import time
+                time.sleep(2)
+                subprocess.check_output('systemctl restart wpa_supplicant@wlan0.service', shell=True)
 
+            # async restart wireless service
+            thread = Thread(target=restart_wireless)
+            thread.start()
+
+            return '', 204
             # TODO: redirect to a page with alert of success or failure of wireless service reset
         except Exception:
             print("Error: error occured in wireless setup:", sys.exc_info()[2])

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -301,25 +301,23 @@ def setup():
         # change wireless configuration (wpa_supplicant-wlan0.conf and wpa_supplicant.conf)
         # sudo sed -i -e"s/^ssid=.*/ssid=\"$SSID\"/" /etc/wpa_supplicant/wpa_supplicant.conf
         # sudo sed -i -e"s/^psk=.*/psk=\"$WIFIPASS\"/" /etc/wpa_supplicant/wpa_supplicant.conf
-        # sudo systemctl disable wpa_supplicant.service
-        # sudo systemctl enable wpa_supplicant@wlan0.service
         
         try:
-            wpa_files = "/etc/wpa_supplicant/wpa_supplicant.conf"
+            wpa_files = "/etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
 
             # set ssid in wpa_supplicant files
             ssid = wireless['ssid']
-            subprocess.check_output('sed -i ".conf" -e "s/ssid=.*/ssid=\"{}\"/" {}'.format(ssid, wpa_files), shell=True)
+            subprocess.check_output('sed -i -e "s/ssid=.*/ssid=\"{}\"/" {}'.format(ssid, wpa_files), shell=True)
             
             # set bssid (if set by user) in wpa_supplicant files
             if 'bssid' in wireless and wireless['bssid']:
                 bssid = wireless['bssid']
-                subprocess.check_output('sed -i ".conf" -e "s/bssid=.*/bssid=\"{}\"/" {}'.format(bssid, wpa_files), shell=True)
+                subprocess.check_output('sed -i -e "s/bssid=.*/bssid=\"{}\"/" {}'.format(bssid, wpa_files), shell=True)
                 
             # set credentials (if set by user) in wpa_supplicant files
             if 'password' in wireless and wireless['password']:
                 psk = wireless['password']
-                subprocess.check_output('sed -i ".conf" -e "s/psk=.*/psk=\"{}\"/" {}'.format(psk, wpa_files), shell=True)
+                subprocess.check_output('sed -i -e "s/psk=.*/psk=\"{}\"/" {}'.format(psk, wpa_files), shell=True)
             
             # restart wireless services
             subprocess.check_output('systemctl status wpa_supplicant@wlan0.service', shell=True)
@@ -334,11 +332,11 @@ def setup():
 
 
 def wireless_credentials():
-    ssid = subprocess.check_output('more ~/wpa_supplicant-wlan0.conf | grep ssid | awk -F "=" \'{print $2}\'', shell=True)
-    psk = subprocess.check_output('more ~/wpa_supplicant-wlan0.conf | grep psk | awk -F "=" \'{print $2}\'', shell=True)
+    ssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep ssid | awk -F "=" \'{print $2}\'', shell=True)
+    psk = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep psk | awk -F "=" \'{print $2}\'', shell=True)
     
     try:
-        bssid = subprocess.check_output('mmore ~/wpa_supplicant-wlan0.conf | grep bssid | awk -F "=" \'{print $2}\'', shell=True)
+        bssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep bssid | awk -F "=" \'{print $2}\'', shell=True)
     except:
         bssid = None
     

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -329,9 +329,16 @@ def setup():
             # set bssid (if set by user) in wpa_supplicant files
             if 'bssid' in wireless and wireless['bssid']:
                 bssid = wireless['bssid']
+                # remove comment for bssid line (if present)
+                subprocess.check_output(
+                    """sudo sed -i '/bssid/s/#//g' {}""".format(wpa_files), shell=True)
                 subprocess.check_output(
                     """sed -i -e 's/bssid=.*/bssid={}/' {}""".format(bssid, wpa_files), shell=True)
-                
+            else:
+                # add comment for bssid line (if present)
+                subprocess.check_output(
+                    """sudo sed -i '/bssid/s/bssid/#bssid/g' {}""".format(wpa_files), shell=True)
+            
             # set credentials (if set by user) in wpa_supplicant files
             if 'password' in wireless and wireless['password']:
                 psk = wireless['password']

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -331,13 +331,13 @@ def setup():
                 bssid = wireless['bssid']
                 # remove comment for bssid line (if present)
                 subprocess.check_output(
-                    """sudo sed -i '/bssid/s/#//g' {}""".format(wpa_files), shell=True)
+                    """sudo sed -i '/bssid/s/# *//g' {}""".format(wpa_files), shell=True)
                 subprocess.check_output(
                     """sed -i -e 's/bssid=.*/bssid={}/' {}""".format(bssid, wpa_files), shell=True)
             else:
                 # add comment for bssid line (if present)
                 subprocess.check_output(
-                    """sudo sed -i '/bssid/s/bssid/#bssid/g' {}""".format(wpa_files), shell=True)
+                    """sudo sed -i '/bssid/s/bssid/# bssid/g' {}""".format(wpa_files), shell=True)
             
             # set credentials (if set by user) in wpa_supplicant files
             if 'password' in wireless and wireless['password']:

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -293,7 +293,7 @@ def delete_pico_recipe():
 
 @main.route('/wifi_scan', methods=['GET'])
 def wifi_scan():
-    wifi_list = subprocess.check_output('./scripts/docker/pi/wifi_scan.sh', shell=True)
+    wifi_list = subprocess.check_output('./scripts/pi/wifi_scan.sh', shell=True)
     networks = []
     for network in wifi_list:
         network_parts = network.split(' ')

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -291,6 +291,21 @@ def delete_pico_recipe():
     return 'Delete Recipe: Failed to find recipe id \"' + recipe_id + '\"', 418
 
 
+@main.route('/wifi_scan', methods=['GET'])
+def wifi_scan():
+    wifi_list = subprocess.check_output('./scripts/docker/pi/wifi_scan.sh', shell=True)
+    networks = []
+    for network in wifi_list:
+        network_parts = network.split(' ')
+        network.append({
+            "bssid": network_parts[0],
+            "ssid": network_parts[1],
+            "signal": network_parts[2],
+            "encryption": network_parts[3]
+        })
+    return scan_results
+
+
 @main.route('/setup', methods=['GET', 'POST'])
 def setup():
     if request.method == 'POST':

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -298,7 +298,6 @@ def available_networks():
     for network in wifi_list.split(b'\n'):
         network_parts = shlex.split(network.decode())
         if len(network_parts) == 6:
-            print(network_parts)
             networks.append({
                 "bssid": network_parts[0],
                 "ssid": network_parts[1],
@@ -324,17 +323,20 @@ def setup():
 
             # set ssid in wpa_supplicant files
             ssid = wireless['ssid']
-            subprocess.check_output('sed -i -e "s/ssid=.*/ssid=\"{}\"/" {}'.format(ssid, wpa_files), shell=True)
+            subprocess.check_output(
+                """sed -i -e 's/ssid=.*/ssid="{}"/' {}""".format(ssid, wpa_files), shell=True)
             
             # set bssid (if set by user) in wpa_supplicant files
             if 'bssid' in wireless and wireless['bssid']:
                 bssid = wireless['bssid']
-                subprocess.check_output('sed -i -e "s/bssid=.*/bssid=\"{}\"/" {}'.format(bssid, wpa_files), shell=True)
+                subprocess.check_output(
+                    """sed -i -e 's/bssid=.*/bssid="{}"/' {}""".format(bssid, wpa_files), shell=True)
                 
             # set credentials (if set by user) in wpa_supplicant files
             if 'password' in wireless and wireless['password']:
                 psk = wireless['password']
-                subprocess.check_output('sed -i -e "s/psk=.*/psk=\"{}\"/" {}'.format(psk, wpa_files), shell=True)
+                subprocess.check_output(
+                    """sed -i -e 's/psk=.*/psk="{}"/' {}""".format(psk, wpa_files), shell=True)
             
             # restart wireless services
             subprocess.check_output('systemctl status wpa_supplicant@wlan0.service', shell=True)
@@ -349,11 +351,11 @@ def setup():
 
 
 def wireless_credentials():
-    ssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep ssid | awk -F "=" \'{print $2}\'', shell=True)
-    psk = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep psk | awk -F "=" \'{print $2}\'', shell=True)
+    ssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep -w ssid | awk -F "=" \'{print $2}\'', shell=True)
+    psk = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep -w psk | awk -F "=" \'{print $2}\'', shell=True)
     
     try:
-        bssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep bssid | awk -F "=" \'{print $2}\'', shell=True)
+        bssid = subprocess.check_output('more /etc/wpa_supplicant/wpa_supplicant-wlan0.conf | grep -w bssid | awk -F "=" \'{print $2}\'', shell=True)
     except:
         bssid = None
     

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -1,13 +1,24 @@
 $(document).ready(function(){
-	$('#b_save_wireless_setup').click(function(){
+    var select = document.querySelector('#wifi_selector'),
+    wifi_bssid = document.querySelector('#wifi_bssid'),
+    wifi_ssid = document.querySelector('#wifi_ssid'),
+    wifi_credentials = document.querySelector('#wifi_credentials');
+    select.addEventListener('change',function(){
+        var selected = $(this).find('option:selected');
+        wifi_bssid.value = selected.data('bssid')
+        wifi_ssid.value = selected.data('ssid')
+        wifi_credentials.value = ''
+    });
+
+    $('#b_save_wireless_setup').click(function(){
         var wireless = {}
-        wireless.bssid = document.getElementById('f_wireless_setup').elements['wifi_bssid'].value;
-        wireless.ssid = document.getElementById('f_wireless_setup').elements['wifi_ssid'].value;
-        wireless.password = document.getElementById('f_wireless_setup').elements['wifi_credentials'].value;
-        
-		$.ajax({
-			url: 'setup',
-			type: 'POST',
+        wireless.bssid = $('#f_wireless_setup').find('#wifi_bssid').val();
+        wireless.ssid = $('#f_wireless_setup').find('#wifi_ssid').val();
+        wireless.password = $('#f_wireless_setup').find('#wifi_credentials').val();
+
+        $.ajax({
+            url: 'setup',
+            type: 'POST',
             data: JSON.stringify(wireless),
             dataType: "json",
             processData: false,
@@ -20,7 +31,7 @@ $(document).ready(function(){
                 showAlert("Error: " + request.responseText, "danger");
                 //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
             },
-		});
+        });
     });
     function showAlert(msg, type){
         $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -1,0 +1,29 @@
+$(document).ready(function(){
+	$('#b_save_wireless_setup').click(function(){
+        var wireless = {}
+        wireless.bssid = document.getElementById('f_wireless_setup').elements['wifi_bssid'].value;
+        wireless.ssid = document.getElementById('f_wireless_setup').elements['wifi_ssid'].value;
+        wireless.password = document.getElementById('f_wireless_setup').elements['wifi_credentials'].value;
+        
+		$.ajax({
+			url: 'wireless',
+			type: 'POST',
+            data: JSON.stringify(wireless),
+            dataType: "json",
+            processData: false,
+            contentType: "application/json; charset=UTF-8",
+            success: function(data) {
+                showAlert("Success!", "success");
+                setTimeout(function () { window.location.href = "/";}, 2000);
+            },
+            error: function(request, status, error) {
+                showAlert("Error: " + request.responseText, "danger");
+                //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
+            },
+		});
+    });
+    function showAlert(msg, type){
+        $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");
+        $('#alert').show();
+    }
+});

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -6,7 +6,7 @@ $(document).ready(function(){
         wireless.password = document.getElementById('f_wireless_setup').elements['wifi_credentials'].value;
         
 		$.ajax({
-			url: 'wireless',
+			url: 'setup',
 			type: 'POST',
             data: JSON.stringify(wireless),
             dataType: "json",
@@ -27,3 +27,11 @@ $(document).ready(function(){
         $('#alert').show();
     }
 });
+function showPassword() {
+    var x = document.getElementById("wifi_credentials");
+    if (x.type === "password") {
+        x.type = "text";
+    } else {
+        x.type = "password";
+    }
+}

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -2,7 +2,7 @@
 {% block content %}
 <form id="f_about">
   <div class="row">
-    <div class="group col-sm-5">
+    <div class="group col-sm-8">
       <div class="card bg-dark text-white">
         <h2>Python Server Version</h2>
         <p>local version: {{git_version}}</p>
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="group col-sm-5">
+    <div class="group col-sm-8">
       <div class="card bg-dark text-white">
         <h2>OS Release Info</h2>
         <pre class="text-white">
@@ -39,8 +39,10 @@
         </pre>
 
         {% if raspberrypi_info %}
-          <h2>Raspberry PI Info</h2>
-          <p>{{raspberrypi_info}}</p>
+          <h3>Raspberry PI Info</h2>
+          <pre class="text-white">
+            <code class="float-left">{{raspberrypi_info}}</code>
+          </pre>
         {% endif %}
       </div>
     </div>

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block content %}
+<form id="f_about">
+  <div class="row">
+    <div class="group col-sm-5">
+      <div class="card bg-dark text-white">
+        <h2>Python Server Version</h2>
+        <p>local version: {{git_version}}</p>
+        {% if git_version != latest_git_sha %}
+          <span class="text-warning">
+            <i class="fa fa-sync" aria-hidden="true"></i>
+            <a href="/restart_server">Update/Restart Server</a>
+            <p>latest version: {{latest_git_sha}}</p>
+          </span>  
+        {% else %}
+          <span class="text-success">
+            <i class="fa fa-check-circle" aria-hidden="true"></i>
+            no update available
+          </span>
+        {% endif %}
+        {% if local_changes %}
+          <span class="text-danger">
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+            Files with Local Conflicting Changes
+            <pre class="text-white">
+              <code class="float-left">{{local_changes}}</code>
+            </pre>
+          </span>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="group col-sm-5">
+      <div class="card bg-dark text-white">
+        <h2>OS Release Info</h2>
+        <pre class="text-white">
+          <code class="float-left">{{os_release}}</code>
+        </pre>
+
+        {% if raspberrypi_info %}
+          <h2>Raspberry PI Info</h2>
+          <p>{{raspberrypi_info}}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="group col-sm-5">
+      
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -34,9 +34,12 @@
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">System</a>
       <div class="dropdown-menu dropdown-menu-right navbar-dark bg-dark" aria-labelledby="navbarDropdown">
+        <a class="dropdown-item nav-link bg-dark" href="/about">About</a>
+        <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_system">Restart System (Pi)</a>
         <a class="dropdown-item nav-link bg-dark" href="/shutdown_system">Shutdown System (Pi)</a>
+        <a class="dropdown-item nav-link bg-dark" href="/setup">Setup WiFi</a>
       </div>
     </li>
   </ul>

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -36,7 +36,6 @@
       <div class="dropdown-menu dropdown-menu-right navbar-dark bg-dark" aria-labelledby="navbarDropdown">
         <a class="dropdown-item nav-link bg-dark" href="/about">About</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
-        <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_system">Restart System (Pi)</a>
         <a class="dropdown-item nav-link bg-dark" href="/shutdown_system">Shutdown System (Pi)</a>
         <a class="dropdown-item nav-link bg-dark" href="/setup">Setup WiFi</a>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -4,11 +4,10 @@
   <form id="f_wireless_setup">
     <div class="form-row">
       <div class="form-group col-sm-5">
-        
         <select id="wifi_selector" class="form-control form-control-sm">
           <option selected>Select Available WiFi Network</option>
           {% for network in available_networks %}
-            <option value="{{network.bssid}}" data-bssid="{{network.bssid}}" data-ssid="{{network.ssid}}">{{network.ssid}} ({{network.bssid}} - {{network.frequency}} Ghz - Channel {{network.channel}})</option>
+            <option value="{{network.bssid}}" data-bssid="{{network.bssid}}" data-ssid="{{network.ssid}}" >{{network.ssid}} ({{network.bssid}} - {{network.frequency}} Ghz - Channel {{network.channel}})</option>
           {% endfor %}
         </select>
         <br/>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -4,20 +4,27 @@
   <form id="f_wireless_setup">
     <div class="form-row">
       <div class="form-group col-sm-5">
-        <input type="text" class="form-control form-control-sm" id="wifi_bssid" placeholder="BSSID (optional - to force 2.4ghz)">
+
+        <input type="text" class="form-control form-control-sm" id="wifi_bssid" value="{{wireless_credentials.bssid}}" placeholder="BSSID (optional - to force 2.4ghz)">
         <small id="wifi_bssid_HelpBlock" class="form-text text-muted">
           Unique MAC address identifing a 2.4ghz wireless network (optional)
         </small>
         <br/>
-        <input type="text" class="form-control form-control-sm" id="wifi_ssid" placeholder="SSID">
+        <input type="text" class="form-control form-control-sm" id="wifi_ssid" value="{{wireless_credentials.ssid}}" placeholder="SSID">
         <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
           Name of Wi-Fi network
         </small>
         <br/>
-        <input type="password" class="form-control form-control-sm" id="wifi_credentials" placeholder="Credentials (WPA-PSK)">
+        <input type="password" class="form-control form-control-sm" id="wifi_credentials" value="{{wireless_credentials.psk}}" placeholder="Credentials (WPA-PSK)">
+        <span class="form-inline text-white float-right">
+          <input type="checkbox" id="show-password" onclick="showPassword()">
+          <label for="show-password" style="padding-left: 0.4em;">Show Password</label>
+        </span>
         <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
           Credentials for Wi-Fi (WPA-PSK)
         </small>
+        
+
         <br/>
         <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_wireless_setup">Save</button>
       </div>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -4,7 +4,16 @@
   <form id="f_wireless_setup">
     <div class="form-row">
       <div class="form-group col-sm-5">
-
+        
+        <select id="wifi_selector" class="form-control form-control-sm">
+          <option selected>Select Available WiFi Network</option>
+          {% for network in available_networks %}
+            <option value="{{network.bssid}}" data-bssid="{{network.bssid}}" data-ssid="{{network.ssid}}">{{network.ssid}} ({{network.bssid}} - {{network.frequency}} Ghz - Channel {{network.channel}})</option>
+          {% endfor %}
+        </select>
+        <br/>
+        <hr/>
+        <br/>
         <input type="text" class="form-control form-control-sm" id="wifi_bssid" value="{{wireless_credentials.bssid}}" placeholder="BSSID (optional - to force 2.4ghz)">
         <small id="wifi_bssid_HelpBlock" class="form-text text-muted">
           Unique MAC address identifing a 2.4ghz wireless network (optional)
@@ -23,8 +32,6 @@
         <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
           Credentials for Wi-Fi (WPA-PSK)
         </small>
-        
-
         <br/>
         <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_wireless_setup">Save</button>
       </div>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+  <script src="static/js/setup.js"></script>
+  <form id="f_wireless_setup">
+    <div class="form-row">
+      <div class="form-group col-sm-5">
+        <input type="text" class="form-control form-control-sm" id="wifi_bssid" placeholder="BSSID (optional - to force 2.4ghz)">
+        <small id="wifi_bssid_HelpBlock" class="form-text text-muted">
+          Unique MAC address identifing a 2.4ghz wireless network (optional)
+        </small>
+        <br/>
+        <input type="text" class="form-control form-control-sm" id="wifi_ssid" placeholder="SSID">
+        <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
+          Name of Wi-Fi network
+        </small>
+        <br/>
+        <input type="password" class="form-control form-control-sm" id="wifi_credentials" placeholder="Credentials (WPA-PSK)">
+        <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
+          Credentials for Wi-Fi (WPA-PSK)
+        </small>
+        <br/>
+        <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_wireless_setup">Save</button>
+      </div>
+    </div>
+  </form>
+  
+  <br/>
+  <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_configuration"></div>
+  <div></div>
+  <div id=alert class='hide'></div>
+{% endblock %}

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -1,7 +1,5 @@
 sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
 /ESSID/{
-    #gsub(/ /,"\\ ",$2)
-    #gsub(/\"/,"",$2)
     essid[c++]=$2
 }
 /Frequency/{
@@ -13,14 +11,18 @@ sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
     channel[f++]=$2
 }
 /Address/{
- gsub(/.*Address: /,"")
- address[a++]=$0
+    gsub(/.*Address: /,"")
+    address[a++]=$0
 }
-/Encryption key/{ encryption[d++]=$2 }
+/Encryption key/{ 
+    encryption[d++]=$2
+}
 /Quality/{
-gsub(/ dBm  /,"")
-signal[b++]=$3
+    gsub(/ dBm  /,"")
+    signal[b++]=$3
 }
 END {
-for( c in essid ) { print address[c],essid[c],frequency[c],channel[c],signal[c],encryption[c] }
+    for( c in essid ) { 
+        print address[c],essid[c],frequency[c],channel[c],signal[c],encryption[c]
+    }
 }'

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -4,6 +4,14 @@ sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
     #gsub(/\"/,"",$2)
     essid[c++]=$2
 }
+/Frequency/{
+    gsub(/ \(Channel .*\)/,"")
+    gsub(/ GHz/,"")
+    frequency[e++]=$2
+}
+/Channel/{
+    channel[f++]=$2
+}
 /Address/{
  gsub(/.*Address: /,"")
  address[a++]=$0
@@ -14,5 +22,5 @@ gsub(/ dBm  /,"")
 signal[b++]=$3
 }
 END {
-for( c in essid ) { print address[c],essid[c],signal[c],encryption[c] }
+for( c in essid ) { print address[c],essid[c],frequency[c],channel[c],signal[c],encryption[c] }
 }'

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -1,0 +1,18 @@
+sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
+/ESSID/{
+    #gsub(/ /,"\\ ",$2)
+    #gsub(/\"/,"",$2)
+    essid[c++]=$2
+}
+/Address/{
+ gsub(/.*Address: /,"")
+ address[a++]=$0
+}
+/Encryption key/{ encryption[d++]=$2 }
+/Quality/{
+gsub(/ dBm  /,"")
+signal[b++]=$3
+}
+END {
+for( c in essid ) { print address[c],essid[c],signal[c],encryption[c] }
+}'

--- a/scripts/pi/wpa_supplicant.conf
+++ b/scripts/pi/wpa_supplicant.conf
@@ -3,7 +3,7 @@ ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 
 network={
-    # bssid="YOUR_2_4_GHZ_BSSID"
+    #bssid=YO:UR:24:GH:ZB:SS:ID
     ssid="YOUR_WIFI_NAME"
     psk="YOUR_WIFI_PASSWORD"
     key_mgmt=WPA-PSK

--- a/scripts/pi/wpa_supplicant.conf
+++ b/scripts/pi/wpa_supplicant.conf
@@ -3,7 +3,7 @@ ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 
 network={
-    #bssid=YO:UR:24:GH:ZB:SS:ID
+    # bssid=YO:UR:24:GH:ZB:SS:ID
     ssid="YOUR_WIFI_NAME"
     psk="YOUR_WIFI_PASSWORD"
     key_mgmt=WPA-PSK


### PR DESCRIPTION
About page /about is intended to be a dumping ground of server information eventually encompassing server logs (download link) and various other information to be used by users to report to the maintainers of the server implementation. Some things about the "restart and update" that get a bit wonky
- if there are local conflicting changes the UI doesn't disable the "update and restart" action which will fail to pull new changes due to the conflicts
- if you change the branch that is being tracked isn't master of `chiefwigms/picobrew_pico` the page will technically lie about the latest change (as it is only tracking master branch git sha) and update/restart will update with the custom tracking branch instead

WiFi Setup page has been tested again 2 of my networks on a Raspberry Pi Zero-W unit successfully (best to configure when connected to the `PICOBREW` AP then ssh sessions and general network availability doesn't get interrupted). The option selector will auto fill in the BSSID and SSID for the user and leave the credentials as something to enter. Things that will need to be supported later if and when requested:
 - ability to configure "no" encryption connections
 - support for non psk networks (enterprise, etc maybe?)
 - there is no "status" on if the wireless restart worked, adding a simple ajax refreshing "is it updated yet?" could have that meantime a refresh of the page should make that clear.
 - Add ability to configure the Access Point (rename ssid or change password)

Resolves https://github.com/chiefwigms/picobrew_pico/issues/38