### PR TITLE
trust machine provided `token` for session log updates

### DIFF
--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -512,7 +512,7 @@ def update_session_log(token, body):
                                'step': active_session.step,
                                'event': event,
                                })
-    socketio.emit('brew_session_update|{}'.format(uid), graph_update)
+    socketio.emit('brew_session_update|{}'.format(token), graph_update)
     active_session.file.write('\n\t{},'.format(json.dumps(session_data)))
     active_session.file.flush()
 

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -458,15 +458,7 @@ def create_session(token, body):
 
 def update_session_log(token, body):
     session_id = body['ZSessionID']
-    uid = get_machine_by_session(session_id)
-
-    if uid is None:
-        error = {
-            'error': 'machine_id {} session {} does not have a matching active session log'.format(token, session_id)
-        }
-        return Response(json.dumps(error), status=400, mimetype='application/json')
-
-    active_session = active_brew_sessions[uid]
+    active_session = active_brew_sessions[token]
 
     if active_session.id == -1:
         # update reference to corrupted active_session


### PR DESCRIPTION
Fixes issues raised by https://github.com/chiefwigms/picobrew_pico/issues/85 when using a Z2+ setup. Instead of looking up the device by the sessionId trust the token provided by the device.