### PR TITLE
Custom access point setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,23 @@ Allows for full control of the PicoBrew Pico S/C/Pro & Zymatic models.  Shout ou
 
 ## Installation
 
-Refer to the [Releases Page](https://github.com/chiefwigms/picobrew_pico/releases) for steps to get up and running with your own Pico server. 
+Refer to the [Releases Page](https://github.com/chiefwigms/picobrew_pico/releases) for steps to get up and running with your own Pico server with a Raspberry Pi device (recommended models include: Raspberry Pi Zero-W or Raspberry Pi 4).
 
-The remainder of this guide oriented around creating a development environment 
+By default the hostname of the RaspberryPi device will be "raspberrypi" and is discoverable on your local network along with the "samba" (or network shares) for sessions and recipes. You can use these to view the files created by the server during interactions with the user and connected devices.
+
+### Debugging Issues
+
+There are two primary ways to help get additional details of errors that occur.
+
+First is to see what is happening in your local browser. Most modern browsers have "development tools" that are included (in Chrome "Settings > More Tools > Developer Tools") and from these there are usually a console log as well as a "Network" tab that shows all the network requests made by the existing experience/page.
+
+Second is to view the application logs from the included python server over an ssh or local keyboard+screen session.
+
+```
+sudo systemctl status rc.local -n <num-log-lines>
+```
+
+The remainder of this guide is oriented around creating a development environment for contributors.
 
 # Development Setup
 

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -376,8 +376,8 @@ def setup():
             subprocess.check_output(
                 """sed -i -e 's/{}/{}/' /etc/hosts""".format(hostname(), new_hostname), shell=True)
 
-            # restart
-            # os.system('shutdown -r now')
+            # restart for new host settings to take effect
+            os.system('shutdown -r now')
 
             return '', 204
         elif 'interface' in payload:

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -1,7 +1,9 @@
 import json
 import os
+import re
 import requests
 import shlex
+import socket
 import subprocess
 import sys
 import traceback
@@ -358,94 +360,127 @@ def available_networks():
 @main.route('/setup', methods=['GET', 'POST'])
 def setup():
     if request.method == 'POST':
-        wireless = request.get_json()
+        payload = request.get_json()
 
-        # change wireless configuration (wpa_supplicant-wlan0.conf and wpa_supplicant.conf)
-        # sudo sed -i -e"s/^ssid=.*/ssid=\"$SSID\"/" /etc/wpa_supplicant/wpa_supplicant.conf
-        # sudo sed -i -e"s/^psk=.*/psk=\"$WIFIPASS\"/" /etc/wpa_supplicant/wpa_supplicant.conf
-        
-        if wireless['interface'] == 'wlan0':
-            try:
-                wpa_files = "/etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
+        if 'hostname' in payload:
+            # change the device hostname and reboot
+            new_hostname = payload['hostname']
 
-                # set ssid in wpa_supplicant files
-                ssid = wireless['ssid']
-                subprocess.check_output(
-                    """sed -i -e 's/ssid=.*/ssid="{}"/' {}""".format(ssid, wpa_files), shell=True)
-                
-                # set bssid (if set by user) in wpa_supplicant files
-                if 'bssid' in wireless and wireless['bssid']:
-                    bssid = wireless['bssid']
-                    # remove comment for bssid line (if present)
+            # check if hostname is only a-z0-9\-
+            if not re.match("^[a-zA-Z0-9-]+$", new_hostname):
+                current_app.logger.error("ERROR: invalid hostname provided: {}".format(new_hostname))
+                return 'Invalid Hostname (only supports a-z 0-9 and - as characters)!', 400
+
+            subprocess.check_output(
+                """echo '{}' > /etc/hostname""".format(new_hostname), shell=True)
+            subprocess.check_output(
+                """sed -i -e 's/{}/{}/' /etc/hosts""".format(hostname(), new_hostname), shell=True)
+
+            # restart
+            # os.system('shutdown -r now')
+
+            return '', 204
+        elif 'interface' in payload:
+            if payload['interface'] == 'wlan0':
+                # change wireless configuration (wpa_supplicant-wlan0.conf and wpa_supplicant.conf)
+                # sudo sed -i -e"s/^ssid=.*/ssid=\"$SSID\"/" /etc/wpa_supplicant/wpa_supplicant.conf
+                # sudo sed -i -e"s/^psk=.*/psk=\"$WIFIPASS\"/" /etc/wpa_supplicant/wpa_supplicant.conf
+            
+                try:
+                    wpa_files = "/etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
+
+                    # set ssid in wpa_supplicant files
+                    ssid = payload['ssid']
                     subprocess.check_output(
-                        """sudo sed -i '/bssid/s/# *//g' {}""".format(wpa_files), shell=True)
+                        """sed -i -e 's/ssid=.*/ssid="{}"/' {}""".format(ssid, wpa_files), shell=True)
+                    
+                    # set bssid (if set by user) in wpa_supplicant files
+                    if 'bssid' in payload and payload['bssid']:
+                        bssid = payload['bssid']
+                        # remove comment for bssid line (if present)
+                        subprocess.check_output(
+                            """sudo sed -i '/bssid/s/# *//g' {}""".format(wpa_files), shell=True)
+                        subprocess.check_output(
+                            """sed -i -e 's/bssid=.*/bssid={}/' {}""".format(bssid, wpa_files), shell=True)
+                    else:
+                        # add comment for bssid line (if present)
+                        subprocess.check_output(
+                            """sudo sed -i '/bssid/s/bssid/# bssid/g' {}""".format(wpa_files), shell=True)
+                    
+                    # set credentials (if set by user) in wpa_supplicant files
+                    if 'password' in payload and payload['password']:
+                        psk = payload['password']
+                        subprocess.check_output(
+                            """sed -i -e 's/psk=.*/psk="{}"/' {}""".format(psk, wpa_files), shell=True)
+                    
+                    def restart_wireless():
+                        import subprocess
+                        import time
+                        time.sleep(2)
+                        subprocess.check_output('systemctl restart wpa_supplicant@wlan0.service', shell=True)
+
+                    # async restart wireless service
+                    thread = Thread(target=restart_wireless)
+                    thread.start()
+
+                    return '', 204
+                    # TODO: redirect to a page with alert of success or failure of wireless service reset
+                except Exception:
+                    current_app.logger.error("ERROR: error occured in wireless setup:", sys.exc_info()[2])
+                    current_app.logger.error(traceback.format_exc())
+                    return 'Wireless Setup Failed!', 418
+            elif payload['interface'] == 'ap0':
+                try:
+                    hostapd_file = "/etc/hostapd/hostapd.conf"
+
+                    # set ssid in hostapd file
+                    ssid = payload['ssid']
                     subprocess.check_output(
-                        """sed -i -e 's/bssid=.*/bssid={}/' {}""".format(bssid, wpa_files), shell=True)
-                else:
-                    # add comment for bssid line (if present)
-                    subprocess.check_output(
-                        """sudo sed -i '/bssid/s/bssid/# bssid/g' {}""".format(wpa_files), shell=True)
-                
-                # set credentials (if set by user) in wpa_supplicant files
-                if 'password' in wireless and wireless['password']:
-                    psk = wireless['password']
-                    subprocess.check_output(
-                        """sed -i -e 's/psk=.*/psk="{}"/' {}""".format(psk, wpa_files), shell=True)
-                
-                def restart_wireless():
-                    import subprocess
-                    import time
-                    time.sleep(2)
-                    subprocess.check_output('systemctl restart wpa_supplicant@wlan0.service', shell=True)
+                        """sed -i -e 's/ssid=.*/ssid="{}"/' {}""".format(ssid, hostapd_file), shell=True)
+                    
+                    # set credentials (if set by user) in hostapd file
+                    if 'password' in payload and payload['password']:
+                        psk = payload['password']
+                        subprocess.check_output(
+                            """sed -i -e 's/wpa_passphrase=.*/wpa_passphrase="{}"/' {}""".format(psk, hostapd_file), shell=True)
 
-                # async restart wireless service
-                thread = Thread(target=restart_wireless)
-                thread.start()
+                    def restart_ap0_interface():
+                        import subprocess
+                        import time
+                        time.sleep(2)
+                        subprocess.check_output('systemctl restart hostapd.service', shell=True)
 
-                return '', 204
-                # TODO: redirect to a page with alert of success or failure of wireless service reset
-            except Exception:
-                current_app.logger.error("ERROR: error occured in wireless setup:", sys.exc_info()[2])
-                current_app.logger.error(traceback.format_exc())
-                return 'Wireless Setup Failed!', 418
-        elif wireless['interface'] == 'ap0':
-            try:
-                hostapd_file = "/etc/hostapd/hostapd.conf"
+                    # async restart hostapd service
+                    thread = Thread(target=restart_ap0_interface)
+                    thread.start()
 
-                # set ssid in hostapd file
-                ssid = wireless['ssid']
-                subprocess.check_output(
-                    """sed -i -e 's/ssid=.*/ssid="{}"/' {}""".format(ssid, hostapd_file), shell=True)
-                
-                # set credentials (if set by user) in hostapd file
-                if 'password' in wireless and wireless['password']:
-                    psk = wireless['password']
-                    subprocess.check_output(
-                        """sed -i -e 's/wpa_passphrase=.*/wpa_passphrase="{}"/' {}""".format(psk, hostapd_file), shell=True)
-
-                def restart_ap0_interface():
-                    import subprocess
-                    import time
-                    time.sleep(2)
-                    subprocess.check_output('systemctl restart hostapd.service', shell=True)
-
-                # async restart hostapd service
-                thread = Thread(target=restart_ap0_interface)
-                thread.start()
-
-                return '', 204
-            except Exception:
-                current_app.logger.error("ERROR: error occured in wireless setup:", sys.exc_info()[2])
-                current_app.logger.error(traceback.format_exc())
-                return 'Wireless Setup Failed!', 418
+                    return '', 204
+                except Exception:
+                    current_app.logger.error("ERROR: error occured in wireless setup:", sys.exc_info()[2])
+                    current_app.logger.error(traceback.format_exc())
+                    return 'Wireless Setup Failed!', 418
+            else:
+                current_app.logger.error("ERROR: invalid interface provided %s".format(payload['interface']))
+                return 'Invalid Interface Provided - Setup Failed!', 418
         else:
-            current_app.logger.error("ERROR: invalid interface provided %s".format(wireless['interface']))
-            return 'Invalid Wireless Interface Provided - Setup Failed!', 418
+            current_app.logger.error("ERROR: unsupported payload received %s".format(payload))
+            return 'Invalid Setup Payload Received - Setup Failed!', 418
     else:
         return render_template('setup.html',
+            hostname=hostname(),
             ap0=accesspoint_credentials(),
             wireless_credentials=wireless_credentials(),
             available_networks=available_networks())
+
+
+def hostname():
+    try:
+        subprocess.check_output("more /etc/hostname", shell=True)
+        return subprocess.check_output("hostname", shell=True).decode("utf-8").strip()
+    except:
+        current_app.logger.warn("WARN: current device doesn't support hostname changes")
+
+    return None
 
 
 def accesspoint_credentials():

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -12,6 +12,7 @@ $(document).ready(function(){
 
     $('#b_save_wireless_setup').click(function(){
         var wireless = {}
+        wireless.interface = 'wlan0';
         wireless.bssid = $('#f_wireless_setup').find('#wifi_bssid').val();
         wireless.ssid = $('#f_wireless_setup').find('#wifi_ssid').val();
         wireless.password = $('#f_wireless_setup').find('#wifi_credentials').val();
@@ -33,13 +34,37 @@ $(document).ready(function(){
             },
         });
     });
+
+    $('#b_save_ap0_setup').click(function(){
+        var ap0 = {}
+        ap0.interface = 'ap0';
+        ap0.ssid = $('#f_ap0_setup').find('#ap0_ssid').val();
+        ap0.password = $('#f_ap0_setup').find('#ap0_credentials').val();
+
+        $.ajax({
+            url: 'setup',
+            type: 'POST',
+            data: JSON.stringify(ap0),
+            dataType: "json",
+            processData: false,
+            contentType: "application/json; charset=UTF-8",
+            success: function(data) {
+                showAlert("Success!", "success");
+                setTimeout(function () { window.location.href = "/";}, 2000);
+            },
+            error: function(request, status, error) {
+                showAlert("Error: " + request.responseText, "danger");
+                //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
+            },
+        });
+    });
     function showAlert(msg, type){
         $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");
         $('#alert').show();
     }
 });
-function showPassword() {
-    var x = document.getElementById("wifi_credentials");
+function showPassword(elementId) {
+    var x = document.getElementById(elementId);
     if (x.type === "password") {
         x.type = "text";
     } else {

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -72,7 +72,7 @@ $(document).ready(function(){
             contentType: "application/json; charset=UTF-8",
             success: function(data) {
                 showAlert("Success!", "success");
-                setTimeout(function () { window.location.href = "/";}, 2000);
+                setTimeout(function () { window.location.href = `//${payload.hostname}/`;}, 2000);
             },
             error: function(request, status, error) {
                 showAlert("Error: " + request.responseText, "danger");

--- a/app/static/js/setup.js
+++ b/app/static/js/setup.js
@@ -58,6 +58,29 @@ $(document).ready(function(){
             },
         });
     });
+
+    $('#b_save_hostname_setup').click(function(){
+        var payload = {}
+        payload.hostname = $('#f_hostname_setup').find('#hostname').val();
+
+        $.ajax({
+            url: 'setup',
+            type: 'POST',
+            data: JSON.stringify(payload),
+            dataType: "json",
+            processData: false,
+            contentType: "application/json; charset=UTF-8",
+            success: function(data) {
+                showAlert("Success!", "success");
+                setTimeout(function () { window.location.href = "/";}, 2000);
+            },
+            error: function(request, status, error) {
+                showAlert("Error: " + request.responseText, "danger");
+                //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
+            },
+        });
+    });
+
     function showAlert(msg, type){
         $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");
         $('#alert').show();

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -35,10 +35,10 @@
       <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">System</a>
       <div class="dropdown-menu dropdown-menu-right navbar-dark bg-dark" aria-labelledby="navbarDropdown">
         <a class="dropdown-item nav-link bg-dark" href="/about">About</a>
+        <a class="dropdown-item nav-link bg-dark" href="/setup">Setup/Configure</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
         <a class="dropdown-item nav-link bg-dark" href="/restart_system">Restart System (Pi)</a>
         <a class="dropdown-item nav-link bg-dark" href="/shutdown_system">Shutdown System (Pi)</a>
-        <a class="dropdown-item nav-link bg-dark" href="/setup">Setup WiFi</a>
       </div>
     </li>
   </ul>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -2,6 +2,10 @@
 {% block content %}
   <script src="static/js/setup.js"></script>
   <form id="f_wireless_setup">
+    <div class="text-white">
+      <h4>Setup Wireless Interface</h4>
+      <p>The upstream wireless interface (ie. wlan0 on raspberrypi setups) is used for connecting to you local home network. Features included that rely on this connect include: importing from picobrew.com and updating source code.</p>
+    </div>
     <div class="form-row">
       <div class="form-group col-sm-5">
         <select id="wifi_selector" class="form-control form-control-sm">
@@ -25,10 +29,10 @@
         <br/>
         <input type="password" class="form-control form-control-sm" id="wifi_credentials" value="{{wireless_credentials.psk}}" placeholder="Credentials (WPA-PSK)">
         <span class="form-inline text-white float-right">
-          <input type="checkbox" id="show-password" onclick="showPassword()">
-          <label for="show-password" style="padding-left: 0.4em;">Show Password</label>
+          <input type="checkbox" id="show-wifi-password" onclick="showPassword('wifi_credentials')">
+          <label for="show-wifi-password" style="padding-left: 0.4em;">Show Password</label>
         </span>
-        <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
+        <small id="wifi_credentials_HelpBlock" class="form-text text-muted">
           Credentials for Wi-Fi (WPA-PSK)
         </small>
         <br/>
@@ -36,6 +40,37 @@
       </div>
     </div>
   </form>
+
+  {% if ap0 %}
+  <br/>
+  <hr/>
+  <br/>
+  <form id="f_ap0_setup">
+    <div class="text-white">
+      <h4>Setup Access Point Interface</h4>
+      <p>This access point (ie. ap0) is used to broadcast the network for your Picobrew devices to connect to.</p>
+    </div>
+    <div class="form-row">
+      <div class="form-group col-sm-5">
+        <input type="text" class="form-control form-control-sm" id="ap0_ssid" value="{{ap0.ssid}}" placeholder="SSID">
+        <small id="wifi_ssid_HelpBlock" class="form-text text-muted">
+          Name of AP network
+        </small>
+        <br/>
+        <input type="password" class="form-control form-control-sm" id="ap0_credentials" value="{{ap0.psk}}" placeholder="Credentials (WPA-PSK)">
+        <span class="form-inline text-white float-right">
+          <input type="checkbox" id="show-ap0-password" onclick="showPassword('ap0_credentials')">
+          <label for="show-ap0-password" style="padding-left: 0.4em;">Show Password</label>
+        </span>
+        <small id="ap0_credentials_HelpBlock" class="form-text text-muted">
+          Credentials for AP (WPA-PSK)
+        </small>
+        <br/>
+        <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_ap0_setup">Save</button>
+      </div>
+    </div>
+  </form>
+  {% endif %}
   
   <br/>
   <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_configuration"></div>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -4,7 +4,7 @@
   <form id="f_wireless_setup">
     <div class="text-white">
       <h4>Setup Wireless Interface</h4>
-      <p>The upstream wireless interface (ie. wlan0 on raspberrypi setups) is used for connecting to you local home network. Features included that rely on this connect include: importing from picobrew.com and updating source code.</p>
+      <p>The upstream wireless interface (ie. interface wlan0 on raspberrypi setups) is used for connecting to you local home network. Some features included may be negatively impacted by not having a value upstream wireless connection to your home network and public internet. Specific features that will be broken include, but aren't limited to: importing from picobrew.com and updating source code.</p>
     </div>
     <div class="form-row">
       <div class="form-group col-sm-5">
@@ -48,7 +48,7 @@
   <form id="f_ap0_setup">
     <div class="text-white">
       <h4>Setup Access Point Interface</h4>
-      <p>This access point (ie. ap0) is used to broadcast the network for your Picobrew devices to connect to.</p>
+      <p>This access point (ie. interface ap0 on raspberrypi setups) is used to broadcast the network for your Picobrew devices to connect to.</p>
     </div>
     <div class="form-row">
       <div class="form-group col-sm-5">
@@ -67,6 +67,32 @@
         </small>
         <br/>
         <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_ap0_setup">Save</button>
+      </div>
+    </div>
+  </form>
+  {% endif %}
+
+  {% if hostname %}
+  <br/>
+  <hr/>
+  <br/>
+  <form id="f_hostname_setup">
+    <div class="text-white">
+      <h4>Setup Hostname</h4>
+      <p>If you want to have a custom hostname for your server you can customize this below. This is useful if you have multiple raspberrypi devices and/or want to have a more memoriable or meaningful hostname for your configuration.</p>
+    </div>
+    <div class="form-row">
+      <div class="form-group col-sm-5">
+        <input type="text" class="form-control form-control-sm" id="hostname" value="{{hostname}}" placeholder="Hostname">
+        <small id="hostname_HelpBlock" class="form-text text-muted">
+          Name of device on the network
+        </small>
+        <br/>
+        <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_hostname_setup">Save</button>
+        <small id="b_save_hostname_setup_HelpBlock" class="form-text text-warning">
+          Changing hostname will restart the RaspberryPi and will be unavailable for a small period of time.
+        </small>
+        
       </div>
     </div>
   </form>

--- a/scripts/pi/firstboot.sh
+++ b/scripts/pi/firstboot.sh
@@ -222,6 +222,7 @@ cat > /certs/req.cnf <<EOF
 keyUsage = critical, digitalSignature, keyAgreement
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
+subjectAltName = @alt_names
 [alt_names]
 DNS.1 = picobrew.com
 DNS.2 = www.picobrew.com


### PR DESCRIPTION
Include additional system level setup / configuration options in the `/setup` experience. Here are 2 new settings of the system that are able to be configured:
1) The Access Point Name and Credentials (only supports `wpa_passphrase`)
2) broadcasted hostname which is helpful if you have multiple raspberrypi setup on your network or want something more memorable than `raspberrypi` as the device's hostname.
![image](https://user-images.githubusercontent.com/2158627/90265433-95193b80-de20-11ea-95e1-f0d8824424c6.png)
