### PR TITLE
Temp sensors misidentified for Zymatic graph #111

### DIFF
--- a/app/main/routes_zymatic_api.py
+++ b/app/main/routes_zymatic_api.py
@@ -171,8 +171,8 @@ def process_log_session(args):
         uid = get_machine_by_session(session)
         temps = [int(temp[2:]) for temp in args['data'].split('|')]
         session_data = {'time': ((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000),
-                        'heat1': temps[0],
-                        'wort': temps[1],
+                        'wort': temps[0],
+                        'heat1': temps[1],
                         'board': temps[2],
                         'heat2': temps[3],
                         'step': active_brew_sessions[uid].step,


### PR DESCRIPTION
@chiefwigms I don't have a Zymatic to confirm the ordering of the temps reported by the Zymatic... but if `temp1` and `wort` are swapped this was the only place that made sense to me. Everywhere else the temps are referred to by these stored names 🤷‍♂️ 

Reference in Issue #111 and Facebook posts by Matt Johnson, https://www.facebook.com/groups/Picobrewers/permalink/2734260643519579/