### PR TITLE
Frontend Support for Changing Temperature/Units

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,3 +1,7 @@
+#options {
+  margin-bottom: 25px;
+  text-align: right;
+}
 .card-header > a {
   display: block;
   position: relative;

--- a/app/static/js/convert_units.js
+++ b/app/static/js/convert_units.js
@@ -1,0 +1,84 @@
+// utility function to convert temperature units
+function convert_temperature(temp, units) {
+    if (units.toLowerCase() == 'imperial') {
+        return (temp * 9/5) + 32  // convert celcius to fahrenheit
+    }
+    return (temp - 32) * 5/9  // convert fahrenheit to celcius
+}
+
+// TODO: expanding and then collapsing the values don't update (and can't force redraw?)
+
+// tabulator formatter, formats temperature to correct units for display based on selected units
+function mutate_temperature(value, formatterParams, onRendered) {
+    let selected_units = $("#unit_selector > label.active > input")[0].id;    
+    // convert if C as server stores F
+    return selected_units == "imperial" ? value : convert_temperature(value, selected_units);
+}
+
+// if set to c -> convert to F
+// if set to f -> keep
+function mutator_edit_temperature(value, formatterParams, onRendered) {
+    let selected_units = $("#unit_selector > label.active > input")[0].id;    
+    // convert to F if C as server stores F
+    return selected_units == "imperial" ? value : convert_temperature(value, "imperial");
+}
+
+// tabulator formatter, formats temperature to correct units for display based on selected units
+function format_temperature(cell, formatterParams, onRendered) {
+    let selected_units = $("#unit_selector > label.active > input")[0].id;
+ 
+    // convert into call to convert_units with optional table selector
+    let temp_units = selected_units == "metric" ? "C" : "F";
+    
+    // convert if C as server stores F
+    return temp_units == "F" ? cell.getValue() : convert_temperature(cell.getValue(), "C");
+}
+
+// converts all visible tabulator tables upon selection of units
+function convert_units(units) {
+    for (index in tables) {
+        tables[index]
+    }
+    let prev_units = localStorage.getItem("units");
+
+    // no-opt; reselected same units
+    if (prev_units == units) return;
+    
+    localStorage.setItem("units", units);
+
+    let temp_units = units == "metric" ? "C" : "F";
+    
+    // <div class="tabulator-col" role="columnheader" aria-sort="none" tabulator-field="temperature" title="" style="min-width: 40px; width: 100px;">
+    //   <div class="tabulator-col-content">
+    //     <div class="tabulator-col-title">Temp (°F)</div>
+    //   </div>
+    // </div>
+    let temp_header_ref = ".tabulator-col[tabulator-field='temperature'] > div.tabulator-col-content > div.tabulator-col-title";
+    $(temp_header_ref).text("Temp (°" + temp_units + ")");
+    
+    // <div class="tabulator-cell" role="gridcell" tabulator-field="temperature" tabindex="0" title="[0 - 208]" style="width: 100px; text-align: center; height: 29px;">104</div>
+    let temp_cells_ref = ".tabulator-cell[tabulator-field='temperature']";
+    $(temp_cells_ref).each(function(index, elem) {
+        let current_temp = elem.textContent;
+        elem.innerText = convert_temperature(current_temp, units);
+    }); 
+    
+    // let re = new RegExp('\[(\d+)\ \-\ (\d)+\]');
+    // matches = re.
+    // temp_range = $(".tabulator-cell tabulator-field='temperature'").title;
+    // temp_range.
+}
+
+$(function() {
+    // select local storage set units
+    let selected_units = localStorage.getItem("units");
+    if (selected_units == null) selected_units = "imperial";
+
+    $("#unit_selector > label > input#" + selected_units ).parent().addClass("active");
+    $("#unit_selector > label > input#" + selected_units ).attr( 'checked', true );
+    $("#unit_selector > label > input#" + selected_units ).parent().siblings().removeClass("active");
+
+    // clear localStorage and initially convert units to previously stored value
+    localStorage.removeItem("units");
+    convert_units(selected_units);
+});

--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -39,10 +39,17 @@ var recipe_table = {
                 "Adjunct4",
             ]
         }},
-        {title:"Temp (°F)", field:"temperature", width:100, hozAlign:"center", validator:["required", "min:0", "max:208", "numeric"], editable:editCheck, editor:"number", editorParams:{
-            min:0,
-            max:208,
-        }},
+        {
+            title: "Temp (°F)", field: "temperature", width: 100, hozAlign: "center",
+            validator: ["required", "min:0", "max:208", "numeric"],
+            editable: editCheck,
+            editorParams: {
+                min: 0,     // -18 C
+                max: 208,   // 98 C
+            },
+            editor: temperature_editor,
+            formatter: format_temperature
+        },
         {title:"Time (min)", field:"step_time", width:100, hozAlign:"center", validator:["required", "min:0", "max:180", "numeric"], editable:editCheck, editor:"number", editorParams:{
             min:0,
             max:180,

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -54,58 +54,8 @@ var recipe_table = {
                 min: 0,     // -18 C
                 max: 208,   // 98 C
             },
-            editor: function(cell, onRendered, success, cancel, editorParams){
-                //cell - the cell component for the editable cell
-                //onRendered - function to call when the editor has been rendered
-                //success - function to call to pass the successfuly updated value to Tabulator
-                //cancel - function to call to abort the edit and return to a normal cell
-                //editorParams - params object passed into the editorParams column definition property
-            
-                //create and style editor
-                var editor = document.createElement("input");
-
-                let selected_units = $("#unit_selector > label.active > input")[0].id;  
-            
-                // Set value of editor to the current value of the cell (converting if display is C)
-                editor.value = selected_units == "imperial" ? cell.getValue() : convert_temperature(cell.getValue(), "metric");
-            
-                //set focus on the select box when the editor is selected (timeout allows for editor to be added to DOM)
-                onRendered(function(){
-                    editor.focus();
-                    editor.style.css = "100%";
-                });
-            
-                //when the value has been set, trigger the cell to update (converting to F if display is C)
-                function successFunc(){
-                    success(selected_units == "imperial" ? editor.value : convert_temperature(editor.value, "imperial"));
-                }
-            
-                editor.addEventListener("change", successFunc);
-                editor.addEventListener("blur", successFunc);
-            
-                //return the editor element
-                return editor;
-            },
-            formatter: function(cell, formatterParams, onRendered){
-                console.log("formatter called");
-                return format_temperature(cell, formatterParams, onRendered);
-            },
-            // mutator: function(value, data, type, params, component) {
-            //     // stored in f; might be viewed in c;
-            //     console.log("mutator called");
-            //     return mutate_temperature(value);
-            // },
-            // mutatorEdit: function(value, data, type, params, component) {
-            //     // stored in f; might be viewed in c;
-            //     // if set to c -> convert to F
-            //     // if set to f -> keep
-            //     console.log("mutator edit called")
-            //     return mutator_edit_temperature(value);
-            // },
-            // accessor: function(value, data, type, params, column) {
-            //     console.log("accessor called")
-            //     return mutate_temperature(value);
-            // }
+            editor: temperature_editor,
+            formatter: format_temperature
         },
         {
             title: "Time (min)", field: "step_time", width: 100, hozAlign: "center", validator: ["required", "min:0", "max:180", "numeric"], editor: "number", editorParams: {

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -48,10 +48,64 @@ var recipe_table = {
             }
         },
         {
-            title: "Temp (°F)", field: "temperature", width: 100, hozAlign: "center", validator: ["required", "min:0", "max:208", "numeric"], editor: "number", editorParams: {
-                min: 0,
-                max: 208,
-            }
+            title: "Temp (°F)", field: "temperature", width: 100, hozAlign: "center",
+            validator: ["required", "min:0", "max:208", "numeric"], 
+            editorParams: {
+                min: 0,     // -18 C
+                max: 208,   // 98 C
+            },
+            editor: function(cell, onRendered, success, cancel, editorParams){
+                //cell - the cell component for the editable cell
+                //onRendered - function to call when the editor has been rendered
+                //success - function to call to pass the successfuly updated value to Tabulator
+                //cancel - function to call to abort the edit and return to a normal cell
+                //editorParams - params object passed into the editorParams column definition property
+            
+                //create and style editor
+                var editor = document.createElement("input");
+
+                let selected_units = $("#unit_selector > label.active > input")[0].id;  
+            
+                // Set value of editor to the current value of the cell (converting if display is C)
+                editor.value = selected_units == "imperial" ? cell.getValue() : convert_temperature(cell.getValue(), "metric");
+            
+                //set focus on the select box when the editor is selected (timeout allows for editor to be added to DOM)
+                onRendered(function(){
+                    editor.focus();
+                    editor.style.css = "100%";
+                });
+            
+                //when the value has been set, trigger the cell to update (converting to F if display is C)
+                function successFunc(){
+                    success(selected_units == "imperial" ? editor.value : convert_temperature(editor.value, "imperial"));
+                }
+            
+                editor.addEventListener("change", successFunc);
+                editor.addEventListener("blur", successFunc);
+            
+                //return the editor element
+                return editor;
+            },
+            formatter: function(cell, formatterParams, onRendered){
+                console.log("formatter called");
+                return format_temperature(cell, formatterParams, onRendered);
+            },
+            // mutator: function(value, data, type, params, component) {
+            //     // stored in f; might be viewed in c;
+            //     console.log("mutator called");
+            //     return mutate_temperature(value);
+            // },
+            // mutatorEdit: function(value, data, type, params, component) {
+            //     // stored in f; might be viewed in c;
+            //     // if set to c -> convert to F
+            //     // if set to f -> keep
+            //     console.log("mutator edit called")
+            //     return mutator_edit_temperature(value);
+            // },
+            // accessor: function(value, data, type, params, column) {
+            //     console.log("accessor called")
+            //     return mutate_temperature(value);
+            // }
         },
         {
             title: "Time (min)", field: "step_time", width: 100, hozAlign: "center", validator: ["required", "min:0", "max:180", "numeric"], editor: "number", editorParams: {
@@ -131,6 +185,7 @@ function update_recipe(recipe_id){
         var recipe = {};
         recipe.id = recipe_id
         recipe.steps = table.getData();
+        // convert temperatures to F
         $.ajax({
 			url: 'update_zseries_recipe',
 			type: 'POST',

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -135,7 +135,6 @@ function update_recipe(recipe_id){
         var recipe = {};
         recipe.id = recipe_id
         recipe.steps = table.getData();
-        // convert temperatures to F
         $.ajax({
 			url: 'update_zseries_recipe',
 			type: 'POST',

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -40,10 +40,16 @@ var recipe_table = {
                 "Pause",
             ]
         }},
-        {title:"Temp (°F)", field:"temperature", width:100, hozAlign:"center", validator:["required", "min:0", "max:208", "numeric"], editor:"number", editorParams:{
-            min:0,
-            max:208,
-        }},
+        {
+            title: "Temp (°F)", field: "temperature", width: 100, hozAlign: "center",
+            validator: ["required", "min:0", "max:208", "numeric"], 
+            editorParams: {
+                min: 0,     // -18 C
+                max: 208,   // 98 C
+            },
+            editor: temperature_editor,
+            formatter: format_temperature
+        },
         {title:"Time (min)", field:"step_time", width:100, hozAlign:"center", validator:["required", "min:0", "max:180", "numeric"], editor:"number", editorParams:{
             min:0,
             max:180,

--- a/app/templates/new_pico_recipe.html
+++ b/app/templates/new_pico_recipe.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
+  <script src="static/js/convert_units.js"></script>
   <script src="static/js/pico_recipe.js"></script>
+  <script>var tables = {};</script>
+  {% include "units_selector.html" %}
   <form id="f_new_recipe">
     <div class="form-row">
       <div class="form-group col-sm-3">
@@ -15,7 +18,11 @@
     </div>
   </form>
   <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_new_recipe"></div>
-  <script>var table = new Tabulator("#t_new_recipe", recipe_table); table.setData(default_data);</script>
+  <script>
+    var table = new Tabulator("#t_new_recipe", recipe_table);
+    table.setData(default_data);
+    tables["new_recipe"] = table;
+  </script>
   <div><button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_new_recipe">Save</button></div>
   <div id=alert class='hide'></div>
 {% endblock %}

--- a/app/templates/new_zseries_recipe.html
+++ b/app/templates/new_zseries_recipe.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
+  <script src="static/js/convert_units.js"></script>
   <script src="static/js/zseries_recipe.js"></script>
+  <script>var tables = {};</script>
+  {% include "units_selector.html" %}
   <form id="f_new_recipe">
     <div class="form-row">
       <div class="form-group col-sm-3">
@@ -9,7 +12,11 @@
     </div>
   </form>
   <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_new_recipe"></div>
-  <script>var table = new Tabulator("#t_new_recipe", recipe_table); table.setData(default_data);</script>
+  <script>
+    var table = new Tabulator("#t_new_recipe", recipe_table);
+    table.setData(default_data);
+    tables["new_recipe"] = table;
+  </script>
   <div><button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_new_recipe">Save</button></div>
   <div id=alert class='hide'></div>
 {% endblock %}

--- a/app/templates/new_zymatic_recipe.html
+++ b/app/templates/new_zymatic_recipe.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
+  <script src="static/js/convert_units.js"></script>
   <script src="static/js/zymatic_recipe.js"></script>
+  <script>var tables = {};</script>
+  {% include "units_selector.html" %}
   <form id="f_new_recipe">
     <div class="form-row">
       <div class="form-group col-sm-3">
@@ -9,7 +12,11 @@
     </div>
   </form>
   <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_new_recipe"></div>
-  <script>var table = new Tabulator("#t_new_recipe", recipe_table); table.setData(default_data);</script>
+  <script>
+    var table = new Tabulator("#t_new_recipe", recipe_table);
+    table.setData(default_data);
+    tables["new_recipe"] = table;
+  </script>
   <div><button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_new_recipe">Save</button></div>
   <div id=alert class='hide'></div>
 {% endblock %}

--- a/app/templates/pico_recipes.html
+++ b/app/templates/pico_recipes.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
   <script src="static/js/server_management.js"></script>
+  <script src="static/js/convert_units.js"></script>
   <script src="static/js/pico_recipe.js"></script>
+  <script>var tables = {};</script>
+  {% include "units_selector.html" %}
   {% include "invalid_file.html" %}
   <div id="accordion">
     {% for recipe in recipes %}
@@ -23,8 +26,9 @@
             recipe_table['rowMoved']=function(row){ 
               document.getElementById("bs_{{recipe['id']}}").style.display = "block";
             }
-            var table = new Tabulator("#t_{{recipe['id']}}", recipe_table);
-            table.setData({{recipe['steps']|tojson}});
+            
+            tables["{{recipe['id']}}"] = new Tabulator("#t_{{recipe['id']}}", recipe_table);
+            tables["{{recipe['id']}}"].setData({{ recipe['steps']| tojson }});
           </script>
         </div>
       </div>

--- a/app/templates/units_selector.html
+++ b/app/templates/units_selector.html
@@ -1,0 +1,12 @@
+<div id="options">
+    <div id="unit_selector" class="btn-group btn-group-toggle" data-toggle="buttons">
+        <label class="btn btn-secondary">
+            <input type="radio" name="options" id="imperial" autocomplete="off"
+                onclick="convert_units('imperial');">Imperial (fahrenheit)</input>
+        </label>
+        <label class="btn btn-secondary">
+            <input type="radio" name="options" id="metric" autocomplete="off" onclick="convert_units('metric');"> Metric
+            (celcius)</input>
+        </label>
+    </div>
+</div>

--- a/app/templates/zseries_recipes.html
+++ b/app/templates/zseries_recipes.html
@@ -3,19 +3,8 @@
 <script src="static/js/server_management.js"></script>
 <script src="static/js/convert_units.js"></script>
 <script src="static/js/zseries_recipe.js"></script>
-<script>var tables = {}</script>
-<div id="options">
-  <div id="unit_selector" class="btn-group btn-group-toggle" data-toggle="buttons">
-    <label class="btn btn-secondary">
-      <input type="radio" name="options" id="imperial" autocomplete="off"
-      onclick="convert_units('imperial');">Imperial (fahrenheit)</input>
-    </label>
-    <label class="btn btn-secondary">
-      <input type="radio" name="options" id="metric" autocomplete="off"
-      onclick="convert_units('metric');"> Metric (celcius)</input>
-    </label>
-  </div>
-</div>
+<script>var tables = {};</script>
+{% include "units_selector.html" %}
 {% include "invalid_file.html" %}
 <div id="accordion">
   {% for recipe in recipes %}
@@ -42,15 +31,6 @@
           }
           recipe_table['rowMoved'] = function (row) {
             document.getElementById("bs_{{recipe['id']}}").style.display = "block";
-          }
-          recipe_table['scrollVertical'] = function(top) {
-            console.log("scroll showed up");
-          }
-          recipe_table['dataLoading'] = function(data) {
-            console.log("data loading");
-          }
-          recipe_table['dataLoaded'] = function(data) {
-            console.log("data loaded");
           }
           
           tables["{{recipe['id']}}"] = new Tabulator("#t_{{recipe['id']}}", recipe_table);

--- a/app/templates/zseries_recipes.html
+++ b/app/templates/zseries_recipes.html
@@ -1,34 +1,64 @@
 {% extends "base.html" %}
 {% block content %}
-  <script src="static/js/server_management.js"></script>
-  <script src="static/js/zseries_recipe.js"></script>
-  {% include "invalid_file.html" %}
-  <div id="accordion">
-    {% for recipe in recipes %}
-    <div class="card bg-dark text-white-50">
-      <h5 class="card-header" id="h_{{recipe['id']}}">
-        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{recipe['id']}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{recipe['id']}}">
-          {{recipe['name']}}
-          <button class="btn btn-sm btn-danger float-right mr-5" type="button" id="bd_{{recipe['id']}}" onclick="event.stopPropagation();event.preventDefault();delete_recipe('{{recipe['id']}}');"><i class="fas fa-trash"></i></button>
-          <button class="btn btn-sm btn-success float-right mr-3" type="button" id="bs_{{recipe['id']}}" onclick="event.stopPropagation();event.preventDefault();update_recipe('{{recipe['id']}}');" style="display:none;"><i class="far fa-save fa-lg"></i></button>
-        </a>
-      </h5>
-      <div id="c_{{recipe['id']}}" class="collapse" aria-labelledby="h_{{recipe['id']}}">
-        <div class="card-body">
-          <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_{{recipe['id']}}"></div>
-          <script>
-            recipe_table['dataEdited']=function(data){ 
-              document.getElementById("bs_{{recipe['id']}}").style.display = "block";
-            }
-            recipe_table['rowMoved']=function(row){ 
-              document.getElementById("bs_{{recipe['id']}}").style.display = "block";
-            }
-            var table = new Tabulator("#t_{{recipe['id']}}", recipe_table);
-            table.setData({{recipe['steps']|tojson}});
-          </script>
+<script src="static/js/server_management.js"></script>
+<script src="static/js/convert_units.js"></script>
+<script src="static/js/zseries_recipe.js"></script>
+<script>var tables = {}</script>
+<div id="options">
+  <div id="unit_selector" class="btn-group btn-group-toggle" data-toggle="buttons">
+    <label class="btn btn-secondary">
+      <input type="radio" name="options" id="imperial" autocomplete="off"
+      onclick="convert_units('imperial');">Imperial (fahrenheit)</input>
+    </label>
+    <label class="btn btn-secondary">
+      <input type="radio" name="options" id="metric" autocomplete="off"
+      onclick="convert_units('metric');"> Metric (celcius)</input>
+    </label>
+  </div>
+</div>
+{% include "invalid_file.html" %}
+<div id="accordion">
+  {% for recipe in recipes %}
+  <div class="card bg-dark text-white-50">
+    <h5 class="card-header" id="h_{{recipe['id']}}">
+      <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{recipe['id']}}" data-parent="#accordion"
+        aria-expanded="false" aria-controls="c_{{recipe['id']}}">
+        {{recipe['name']}}
+        <button class="btn btn-sm btn-danger float-right mr-5" type="button" id="bd_{{recipe['id']}}"
+          onclick="event.stopPropagation();event.preventDefault();delete_recipe('{{recipe['id']}}');"><i
+            class="fas fa-trash"></i></button>
+        <button class="btn btn-sm btn-success float-right mr-3" type="button" id="bs_{{recipe['id']}}"
+          onclick="event.stopPropagation();event.preventDefault();update_recipe('{{recipe['id']}}');"
+          style="display:none;"><i class="far fa-save fa-lg"></i></button>
+      </a>
+    </h5>
+    <div id="c_{{recipe['id']}}" class="collapse" aria-labelledby="h_{{recipe['id']}}">
+      <div class="card-body">
+        <div class="table-sm table-striped table-bordered table-light" style="width: 830px;" id="t_{{recipe['id']}}">
         </div>
+        <script>
+          recipe_table['dataEdited'] = function (data) {
+            document.getElementById("bs_{{recipe['id']}}").style.display = "block";
+          }
+          recipe_table['rowMoved'] = function (row) {
+            document.getElementById("bs_{{recipe['id']}}").style.display = "block";
+          }
+          recipe_table['scrollVertical'] = function(top) {
+            console.log("scroll showed up");
+          }
+          recipe_table['dataLoading'] = function(data) {
+            console.log("data loading");
+          }
+          recipe_table['dataLoaded'] = function(data) {
+            console.log("data loaded");
+          }
+          
+          tables["{{recipe['id']}}"] = new Tabulator("#t_{{recipe['id']}}", recipe_table);
+          tables["{{recipe['id']}}"].setData({{ recipe['steps']| tojson }});
+        </script>
       </div>
     </div>
-    {% endfor %}
   </div>
+  {% endfor %}
+</div>
 {% endblock %}

--- a/app/templates/zymatic_recipes.html
+++ b/app/templates/zymatic_recipes.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
   <script src="static/js/server_management.js"></script>
+  <script src="static/js/convert_units.js"></script>
   <script src="static/js/zymatic_recipe.js"></script>
+  <script>var tables = {};</script>
+  {% include "units_selector.html" %}
   {% include "invalid_file.html" %}
   <div id="accordion">
     {% for recipe in recipes %}
@@ -23,8 +26,9 @@
             recipe_table['rowMoved']=function(row){ 
               document.getElementById("bs_{{recipe['id']}}").style.display = "block";
             }
-            var table = new Tabulator("#t_{{recipe['id']}}", recipe_table);
-            table.setData({{recipe['steps']|tojson}});
+
+            tables["{{recipe['id']}}"] = new Tabulator("#t_{{recipe['id']}}", recipe_table);
+            tables["{{recipe['id']}}"].setData({{ recipe['steps']| tojson }});
           </script>
         </div>
       </div>


### PR DESCRIPTION
There is one edge case that isn't working right now. I didn't dive into Tabulator too much... but the accordion logic is messing with my convert temp logic. Tried various different callbacks from Tabulator for formatting data and none of them worked (or I just plain screwed up). Though this does work fairly well and if you happen to do the following hairbrained actions (yeah I know who you are!) then well just change your behavior #user-error.

Displaying demo of feature at work (browse/edit recipe)
![picobrew-change-unit](https://user-images.githubusercontent.com/2158627/95404334-be1af180-08e2-11eb-9f1e-8305bfe28394.gif)

Displaying demo of feature at work (create/new recipe)
![pico-convert-new-recipe](https://user-images.githubusercontent.com/2158627/95404848-2fa76f80-08e4-11eb-89df-0038fb7bade1.gif)


**Not handled/covered by this PR.**

1) expand a recipe
2) collapse same recipe
3) convert units
4) expand same recipe
5) yeah... just refresh the page... as this doesn't work right now

Demo of the edge case issue.
![pico-edge-case](https://user-images.githubusercontent.com/2158627/95404844-2ae2bb80-08e4-11eb-82fc-95444a93c1f3.gif)

Resolves #66 for giving users a way to change the temperature/units of the recipes as viewed in the UI.