### PR TITLE
Fix add step button, sort lists

### DIFF
--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -147,7 +147,7 @@ def delete_zymatic_recipe():
 def load_zymatic_recipes():
     files = list(zymatic_recipe_path().glob(file_glob_pattern))
     recipes = [load_zymatic_recipe(file) for file in files]
-    return list(filter(lambda x: x.name != None, recipes))
+    return list(sorted(filter(lambda x: x.name != None, recipes), key=lambda x: x.name))
 
 
 def load_zymatic_recipe(file):
@@ -240,7 +240,7 @@ def delete_zseries_recipe():
 def load_zseries_recipes():
     files = list(zseries_recipe_path().glob(file_glob_pattern))
     recipes = [load_zseries_recipe(file) for file in files]
-    return list(filter(lambda x: x.name != None, recipes))
+    return list(sorted(filter(lambda x: x.name != None, recipes), key=lambda x: x.name))
 
 
 def load_zseries_recipe(file):
@@ -594,7 +594,7 @@ def about():
 def load_pico_recipes():
     files = list(pico_recipe_path().glob(file_glob_pattern))
     recipes = [load_pico_recipe(file) for file in files]
-    return list(filter(lambda x: x.name != None, recipes))
+    return list(sorted(filter(lambda x: x.name != None, recipes), key=lambda x: x.name))
 
 
 def load_pico_recipe(file):
@@ -648,7 +648,7 @@ def load_brew_sessions(uid=None):
         files = list(brew_archive_sessions_path().glob("[^_.]*#{}*.json".format(uid)))
     else:
         files = list(brew_archive_sessions_path().glob(file_glob_pattern))
-    brew_sessions = [parse_brew_session(file) for file in files]
+    brew_sessions = [parse_brew_session(file) for file in sorted(files, reverse=True)]
     return list(filter(lambda x: x != None, brew_sessions))
 
 
@@ -671,7 +671,7 @@ def load_active_ferm_sessions():
 
 def load_ferm_sessions():
     files = list(ferm_archive_sessions_path().glob(file_glob_pattern))
-    ferm_sessions = [parse_ferm_session(file) for file in files]
+    ferm_sessions = [parse_ferm_session(file) for file in sorted(files, reverse=True)]
     return list(filter(lambda x: x != None, ferm_sessions))
 
 def parse_iSpindel_session(file):
@@ -692,7 +692,7 @@ def load_active_iSpindel_sessions():
 
 def load_iSpindel_sessions():
     files = list(iSpindel_archive_sessions_path().glob(file_glob_pattern))
-    iSpindel_sessions = [parse_iSpindel_session(file) for file in files]
+    iSpindel_sessions = [parse_iSpindel_session(file) for file in sorted(files, reverse=True)]
     return list(filter(lambda x: x != None, iSpindel_sessions))
 
 # Read initial recipe list on load

--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -1,11 +1,20 @@
-var plusIcon = function (cell, formatterParams) {
-    return "<i class='far fa-plus-square fa-lg'></i>";
-}
-var minusIcon = function (cell, formatterParams) {
-    return "<i class='far fa-minus-square fa-lg'></i>";
+var fixedRows = 3
+
+function rowIsEditable(cell) {
+    var pos = cell.getTable().getRowPosition(cell.getRow());
+    if (pos < fixedRows)
+       return false;
+    else
+       return true;
 }
 var editCheck = function (cell) {
-    return !(["Preparing To Brew", "Heating"].includes(cell.getRow().getCell("name").getValue()));
+    return rowIsEditable(cell);
+}
+var plusIcon = function (cell, formatterParams) {
+        return rowIsEditable(cell)?"<i class='far fa-plus-square fa-lg'></i>":"";
+}
+var minusIcon = function (cell, formatterParams) {
+        return rowIsEditable(cell)?"<i class='far fa-minus-square fa-lg'></i>":"";
 }
 function showAlert(msg, type) {
     $('#alert').html("<div class='w-100 alert text-center alert-" + type + "'>" + msg + "</div>");
@@ -122,13 +131,17 @@ var recipe_table = {
         {
             formatter: plusIcon, width: 49, hozAlign: "center",
             cellClick: function (e, cell) {
-                cell.getTable().addRow({}, false, cell.getRow());
+                if (rowIsEditable(cell))
+                    cell.getTable().addRow(Object.assign({}, cell.getRow().getData()), false, cell.getRow()).then(function(row) {
+                        row.update({name: "New Step"});
+                    });
             }
         },
         {
             formatter: minusIcon, width: 49, hozAlign: "center",
             cellClick: function (e, cell) {
-                cell.getRow().delete();
+                if (rowIsEditable(cell))
+                    cell.getRow().delete();
             }
         },
     ],

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -124,7 +124,9 @@ var recipe_table = {
         {
             formatter: plusIcon, width: 49, hozAlign: "center",
             cellClick: function (e, cell) {
-                cell.getTable().addRow({}, false, cell.getRow());
+                cell.getTable().addRow(Object.assign({}, cell.getRow().getData()), false, cell.getRow()).then(function(row) {
+                    row.update({name: "New Step"});
+                });
             }
         },
         {

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -119,7 +119,9 @@ var recipe_table = {
         {
             formatter: plusIcon, width: 49, hozAlign: "center",
             cellClick: function (e, cell) {
-                cell.getTable().addRow({}, false, cell.getRow());
+                cell.getTable().addRow(Object.assign({}, cell.getRow().getData()), false, cell.getRow()).then(function(row) {
+                    row.update({name: "New Step"});
+                });
             }
         },
         {


### PR DESCRIPTION
Fixed the recipe add step buttons by copying the row and changing the name to "New Step."
For the Pico S/C/Pro recipes, improved the locking of the first three rows, but other rows can still be moved into the first three since Tabulator doesn't appear to support making some rows immovable.
Sort recipes by recipe name and sessions by filename in reverse order which puts the newest at the top.