### PR TITLE
Issue #145 fix new recipe step (data.location isn't set so throws error)

### DIFF
--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -101,7 +101,7 @@ var recipe_table = {
             editable: false,
             mutator: (value, data, type, params, component) => {
                 // type is always data (field isn't editable)
-                if (data.location.indexOf("Adjunct") == 0)
+                if (data.location && data.location.indexOf("Adjunct") == 0)
                     return data.hop_time == undefined ? data.step_time : data.hop_time;
                 else
                     return "";

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -102,7 +102,7 @@ var recipe_table = {
             editable: false,
             mutator: (value, data, type, params, component) => {
                 // type is always data (field isn't editable)
-                if (data.location.indexOf("Adjunct") == 0)
+                if (data.location && data.location.indexOf("Adjunct") == 0)
                     return data.hop_time == undefined ? data.step_time : data.hop_time;
                 else
                     return "";

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -97,7 +97,7 @@ var recipe_table = {
             editable: false,
             mutator: (value, data, type, params, component) => {
                 // type is always data (field isn't editable)
-                if (data.location.indexOf("Adjunct") == 0)
+                if (data.location && data.location.indexOf("Adjunct") == 0)
                     return data.hop_time == undefined ? data.step_time : data.hop_time;
                 else
                     return "";


### PR DESCRIPTION
```
zseries_recipe.js:110 Uncaught (in promise) TypeError: Cannot read property 'indexOf' of undefined
at Object.mutator (zseries_recipe.js:110)
```

This error is caused due to a new step being added not having anything set for the data so `data.location` returns undefined which when used without a null-safety check throws an error and fails to create the new row for the recipe.