### PR TITLE
calculate hop_time again upon location changes

### DIFF
--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -54,6 +54,9 @@ var recipe_table = {
                     "Adjunct3",
                     "Adjunct4",
                 ]
+            },
+            cellEdited: (cell) => {
+                calculate_hop_timing(cell.getTable().getData(), cell.getTable())
             }
         },
         {

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -185,11 +185,22 @@ function calculate_hop_timing(data, provided_table = undefined) {
         var rows = provided_table.getRows();
         var adjunctSteps = rows.filter(row => row.getData().location.indexOf("Adjunct") == 0);
 
-        var cumulative_hop_time = 0;
+        var cumulative_hop_time = {
+            "Adjunct1": 0,
+            "Adjunct2": 0,
+            "Adjunct3": 0,
+            "Adjunct4": 0
+        };
         adjunctSteps.slice().reverse().forEach(adjunctRow => {
             var row_data = adjunctRow.getData();
-            cumulative_hop_time += row_data.step_time;
-            adjunctRow.update({ "hop_time": cumulative_hop_time });
+            for (x in cumulative_hop_time) {
+                if (row_data.location <= "Adjunct" + x) {
+                    cumulative_hop_time[x] += row_data.step_time
+                }
+            }
+
+            // cumulative_hop_time += row_data.step_time;
+            adjunctRow.update({ "hop_time": cumulative_hop_time[row_data.location] });
         });
     }
 }

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -58,6 +58,9 @@ var recipe_table = {
                     "Adjunct4",
                     "Pause",
                 ]
+            },
+            cellEdited: (cell) => {
+                calculate_hop_timing(cell.getTable().getData(), cell.getTable())
             }
         },
         {

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -53,6 +53,9 @@ var recipe_table = {
                     "Adjunct4",
                     "Pause",
                 ]
+            },
+            cellEdited: (cell) => {
+                calculate_hop_timing(cell.getTable().getData(), cell.getTable())
             }
         },
         {


### PR DESCRIPTION
As found in https://github.com/chiefwigms/picobrew_pico/pull/146 the hop_time calculation wasn't retriggered upon `location` changing for the row so I added this `cellEdited` callback to the `location` cells as well.