### PR TITLE
restore active picoferm session upon reboot

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,9 +10,11 @@ BASE_PATH = Path(__file__).parents[1]
 
 socketio = SocketIO()
 
+
 def create_dir(dir_path):
     # create the directory and any missing parent directories, if it doesn't already exist
     pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+
 
 def create_app(debug=False):
     """Create an application."""
@@ -26,7 +28,8 @@ def create_app(debug=False):
     from .main.config import MachineType
     from .main.model import PicoBrewSession, PicoFermSession, PicoStillSession, iSpindelSession
     from .main.routes_frontend import initialize_data
-    from .main.session_parser import restore_active_sessions, active_brew_sessions, active_ferm_sessions, active_still_sessions, active_iSpindel_sessions
+    from .main.session_parser import (restore_active_sessions, active_brew_sessions,
+                                      active_ferm_sessions, active_still_sessions, active_iSpindel_sessions)
 
     from .main import main as main_blueprint
 
@@ -52,7 +55,7 @@ def create_app(debug=False):
         FIRMWARE_PATH=BASE_PATH.joinpath('app/firmware'),
         SERVER_CONFIG=server_cfg
     )
-    
+
     # create subdirectories if they don't already exist
     create_dir(app.config['RECIPES_PATH'].joinpath('pico'))
     create_dir(app.config['RECIPES_PATH'].joinpath('zymatic'))
@@ -68,23 +71,28 @@ def create_app(debug=False):
         initialize_data()
 
     if 'aliases' in server_cfg:
-        machine_types = [MachineType.ZSERIES, MachineType.ZYMATIC, MachineType.PICOBREW, MachineType.PICOBREW_C, MachineType.PICOFERM, MachineType.ISPINDEL]
+        machine_types = [MachineType.ZSERIES, MachineType.ZYMATIC, MachineType.PICOBREW,
+                         MachineType.PICOBREW_C, MachineType.PICOFERM, MachineType.ISPINDEL]
         for mtype in machine_types:
             aliases = server_cfg['aliases']
             if mtype in aliases and aliases[mtype] is not None:
                 for uid in aliases[mtype]:
                     if uid in aliases[mtype] and uid != "uid":
                         if mtype == MachineType.PICOFERM:
-                            active_ferm_sessions[uid] = PicoFermSession()
+                            if uid not in active_ferm_sessions:
+                                active_ferm_sessions[uid] = PicoFermSession()
                             active_ferm_sessions[uid].alias = aliases[mtype][uid]
                         elif mtype == MachineType.ISPINDEL:
-                            active_iSpindel_sessions[uid] = iSpindelSession()
+                            if uid not in active_iSpindel_sessions:
+                                active_iSpindel_sessions[uid] = iSpindelSession()
                             active_iSpindel_sessions[uid].alias = aliases[mtype][uid]
                         elif mtype == MachineType.PICOSTILL:
-                            active_still_sessions[uid] = PicoStillSession()
+                            if uid not in active_still_sessions:
+                                active_still_sessions[uid] = PicoStillSession()
                             active_still_sessions[uid].alias = aliases[mtype][uid]
                         else:
-                            active_brew_sessions[uid] = PicoBrewSession(mtype)
+                            if uid not in active_brew_sessions:
+                                active_brew_sessions[uid] = PicoBrewSession(mtype)
                             active_brew_sessions[uid].alias = aliases[mtype][uid]
                             active_brew_sessions[uid].is_pico = True if mtype == MachineType.PICOBREW else False
 

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -11,6 +11,7 @@ class MachineType(str, Enum):
     ZYMATIC = 'Zymatic'
     ISPINDEL = 'iSpindel'
 
+
 # server config
 def server_config():
     return current_app.config['SERVER_CONFIG']

--- a/app/main/firmware.py
+++ b/app/main/firmware.py
@@ -1,5 +1,6 @@
 from .config import MachineType, server_config
-from distutils.version import LooseVersion, StrictVersion
+from distutils.version import LooseVersion
+
 
 def firmware_filename(device: MachineType, version: str):
     firmware_prefix = device.lower()

--- a/app/main/model.py
+++ b/app/main/model.py
@@ -1,5 +1,6 @@
 import shutil
-from .config import MachineType, brew_archive_sessions_path, ferm_archive_sessions_path, still_archive_sessions_path, iSpindel_archive_sessions_path
+from .config import (MachineType, brew_archive_sessions_path, ferm_archive_sessions_path,
+                     still_archive_sessions_path, iSpindel_archive_sessions_path)
 
 
 ZYMATIC_LOCATION = {

--- a/app/main/recipe_import.py
+++ b/app/main/recipe_import.py
@@ -6,7 +6,6 @@ from .recipe_parser import (
 )
 from .config import MachineType
 from flask import current_app
-from typing import Optional
 
 
 def PicoSyncURI(mach_uid: str, rfid: str) -> str:
@@ -96,12 +95,20 @@ def import_recipes_z(mach_uid: str):
     for recipe in recipe_list["Recipes"]:
         rid = recipe["ID"]
         # recipes imported from brewcrafter have no ID and have external steps
-        # Example of External Recipe Payload: {'ID': None, 'Name': 'Beekeeper Honey Brown', 'Kind': 2, 'Uri': 'https://www.brewcrafter.com/recipe/steps/4f202520-a28c-44a6-76d6-c1298652a4fb', 'Abv': -1, 'Ibu': -1} 
-        if rid != None:
+        # Example of External Recipe Payload:
+        # {
+        #   'ID': None,
+        #   'Name': 'Beekeeper Honey Brown',
+        #   'Kind': 2,
+        #   'Uri': 'https://www.brewcrafter.com/recipe/steps/4f202520-a28c-44a6-76d6-c1298652a4fb',
+        #   'Abv': -1,
+        #   'Ibu': -1
+        # }
+        if rid is not None:
             name = recipe["Name"]
             current_app.logger.debug(f"fetching recipe id='{rid}' and name='{name}'")
             session.headers = requests.structures.CaseInsensitiveDict(
-                {"host": "www.picobrew.com", "Authorization": Z_AUTH_TOKEN,}
+                {"host": "www.picobrew.com", "Authorization": Z_AUTH_TOKEN}
             )
 
             uri = ZSeriesDataSyncURI(mach_uid, rid)

--- a/app/main/recipe_parser.py
+++ b/app/main/recipe_parser.py
@@ -5,6 +5,7 @@ from .config import zymatic_recipe_path, pico_recipe_path, zseries_recipe_path
 from .model import PICO_LOCATION, ZYMATIC_LOCATION, ZSERIES_LOCATION
 from flask import current_app
 
+
 class ZymaticRecipeStep():
     def __init__(self):
         self.name = None
@@ -142,7 +143,7 @@ class ZSeriesRecipe():
                 step.step_time = 0 if 'step_time' not in recipe_step else int(recipe_step['step_time'])
                 step.location = recipe_step.get('location', 'PassThru') or 'PassThru'
                 if step.location == 'PassThrough':
-                    step.location = 'PassThru' 
+                    step.location = 'PassThru'
                 step.drain_time = 0 if 'drain_time' not in recipe_step else int(recipe_step['drain_time'])
                 self.steps.append(step)
 
@@ -175,6 +176,7 @@ class ZSeriesRecipe():
         with open(file, 'w') as f:
             json.dump(updated_recipe, f, indent=4, sort_keys=True)
 
+
 def ZSeriesRecipeImport(recipe):
     r = {}
     r['name'] = recipe['Name']
@@ -199,9 +201,9 @@ def ZSeriesRecipeImport(recipe):
 
     # This will cause a circular import
     # Perhaps re-factor "live state" out into its own module?
-    #existing = load_zseries_recipes()
-    #conflict = [old.id for old in existing if old.id == r['id']]
-    #if conflict:
+    # existing = load_zseries_recipes()
+    # conflict = [old.id for old in existing if old.id == r['id']]
+    # if conflict:
     #    current_app.logger.error(f'Conflicting Z-series recipe IDs: {conflicts}')
     #    return None
 
@@ -210,7 +212,6 @@ def ZSeriesRecipeImport(recipe):
     if not filename.exists():
         with open(filename, "w") as file:
             json.dump(r, file, indent=4, sort_keys=True)
-
 
 
 class PicoBrewRecipeStep():

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -173,7 +173,7 @@ def new_zseries_recipe():
 def new_zseries_recipe_save():
     recipe = request.get_json()
     recipe['id'] = increment_zseries_recipe_id()
-    recipe['start_water'] = 13.1
+    recipe['start_water'] = recipe.get('start_water', 13.1)
     filename = zseries_recipe_path().joinpath('{}.json'.format(recipe['name'].replace(' ', '_')))
     if not filename.exists():
         with open(filename, "w") as file:
@@ -728,9 +728,11 @@ def initialize_data():
 # utilities
 
 def increment_zseries_recipe_id():
-    recipe_id = -1
-    for r in get_zseries_recipes():
-        if r.id > recipe_id:
-            recipe_id = r.id
+    recipe_id = 1
+    found = False
 
-    return recipe_id + 1
+    recipe_ids = [r.id for r in get_zseries_recipes()]
+    while recipe_id in recipe_ids:
+        recipe_id += 1
+
+    return recipe_id

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -205,13 +205,13 @@ pico_still_args = {
     'picoUid': fields.Str(required=True),       # 32 character alpha-numeric serial number
     'picoStillUid': fields.Str(required=True),   # 12 character alpha-numeric serial number
 }
-
 # Can Use Still: /API/pico/canUsePicoStill?picoUid={UID}&picoStillUid={UID}
 #    Response: '#{0}#\r\n' where {0} : T (or F?)
 @main.route('/API/pico/canUsePicoStill')
 @use_args(pico_still_args, location='querystring')
 def process_can_use_pico_still(args):
     return '#T#\r\n'
+
 
 # Has cleaned still: /API/pico/hasCleanedAck?picoUid={UID}&picoStillUid={UID}
 #    Response: '#{0}#\r\n' where {0} : T (or F?)
@@ -220,6 +220,7 @@ def process_can_use_pico_still(args):
 def process_is_cleaned(args):
     return '#T#\r\n'
 
+
 # Set cleaned still: /API/pico/setCleanedAck?picoUid={UID}&picoStillUid={UID}
 #    Response: '#T#\r\n'
 # Allows a user override of hasCleanedAck if unsuccessful
@@ -227,7 +228,6 @@ def process_is_cleaned(args):
 @use_args(pico_still_args, location='querystring')
 def process_set_cleaned(args):
     return '#T#\r\n'
-
 
 
 # -------- Utility --------

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -13,6 +13,7 @@ from .session_parser import active_ferm_sessions
 
 arg_parser = FlaskParser()
 
+
 # Register: /API/PicoFerm/isRegistered?uid={uid}&token={token}
 # Response: '#{0}#' where {0} : 1 = Registered, 0 = Not Registered
 ferm_registered_args = {
@@ -107,11 +108,14 @@ def process_log_ferm_dataset(args):
     if (datetime.now().date() - active_ferm_sessions[uid].start_time.date()).days > 14:
         active_ferm_sessions[uid].file.write('{}\n]'.format(log_data[:-2]))
         active_ferm_sessions[uid].cleanup()
+        # The server makes a determination when fermenting is done based on the datalog after it sends '2,4'
         return '#2,4#'
     else:
         active_ferm_sessions[uid].file.write(log_data)
         active_ferm_sessions[uid].file.flush()
-        return '#10,0#'  # Errors like '10,16' send data but mark data error.  '10,0' tells the PicoFerm to continue to send data.  The server makes a determination when fermenting is done based on the datalog after it sends '2,4'
+        # Errors like '10,16' send data but mark data error.
+        # '10,0' tells the PicoFerm to continue to send data.
+        return '#10,0#'
 
 
 # -------- Utility --------

--- a/app/main/routes_picostill_api.py
+++ b/app/main/routes_picostill_api.py
@@ -1,19 +1,11 @@
-import json
-import uuid
-import os
-from datetime import datetime
-from flask import current_app, request, Response, abort, send_from_directory
+from flask import current_app, send_from_directory
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
-from enum import Enum
-from random import seed, randint
+from random import seed
 
-from .. import socketio
 from . import main
 from .config import picostill_firmware_path
 from .firmware import MachineType, firmware_filename, firmware_upgrade_required, minimum_firmware
-from .routes_frontend import get_zseries_recipes, load_brew_sessions
-from .session_parser import active_brew_sessions
 
 
 arg_parser = FlaskParser()

--- a/app/main/test_recipe_import.py
+++ b/app/main/test_recipe_import.py
@@ -1,6 +1,5 @@
 from .recipe_import import import_recipes, import_recipes_classic, ImportException
 from .config import MachineType
-import requests
 import unittest
 import mock
 from flask import Flask
@@ -22,18 +21,15 @@ def mocked_requests_get(*args, **kwargs):
 class TestRecipeImport(unittest.TestCase):
     app = Flask('test')
 
-
     @mock.patch('app.main.recipe_import.import_recipes_classic')
     def test_calling_zymatic_import_function(self, mock_request):
         import_recipes('test', 'test', None, MachineType.ZYMATIC)
         mock_request.assert_called_once()
 
-
     @mock.patch('app.main.recipe_import.import_recipes_z')
     def test_zymatic_import_function(self, mock_request):
         import_recipes('test', 'test', None, MachineType.ZSERIES)
         mock_request.assert_called_once()
-
 
     @mock.patch('requests.get')
     def test_classic_fetch_failure_blank_response(self, mock_request):
@@ -42,14 +38,12 @@ class TestRecipeImport(unittest.TestCase):
             import_recipes_classic('test', 'test', None, MachineType.ZYMATIC)
         mock_request.assert_called_once()
 
-
     @mock.patch('requests.get')
     def test_classic_fetch_failure_invalid_response(self, mock_request):
         mock_request.text = '#Invalid|#'
         with self.assertRaises(ImportException):
             import_recipes_classic('test', 'test', None, MachineType.ZYMATIC)
         mock_request.assert_called_once()
-
 
     @mock.patch('requests.get')
     def test_classic_fetch_failure_incomplete_response(self, mock_request):
@@ -58,14 +52,13 @@ class TestRecipeImport(unittest.TestCase):
             import_recipes_classic('test', 'test', None, MachineType.ZYMATIC)
         mock_request.assert_called_once()
 
-
     @mock.patch('requests.get', side_effect=mocked_requests_get)
     @mock.patch('app.main.recipe_import.PicoBrewRecipeImport')
     def test_classic_fetch_success_complete_response(self, recipe_mocker, mock_request):
         recipe_mocker.return_value = None
-        import_recipes_classic('test', 'test', 'test_rfid', MachineType.PICOBREW)
+        import_recipes_classic(
+            'test', 'test', 'test_rfid', MachineType.PICOBREW)
         mock_request.assert_called_once()
         recipe_mocker.assert_called_once()
-        recipe_mocker.assert_called_with(recipe='#good stuff#', rfid='test_rfid')
-
-    
+        recipe_mocker.assert_called_with(
+            recipe='#good stuff#', rfid='test_rfid')

--- a/app/main/test_recipe_import.py
+++ b/app/main/test_recipe_import.py
@@ -56,9 +56,7 @@ class TestRecipeImport(unittest.TestCase):
     @mock.patch('app.main.recipe_import.PicoBrewRecipeImport')
     def test_classic_fetch_success_complete_response(self, recipe_mocker, mock_request):
         recipe_mocker.return_value = None
-        import_recipes_classic(
-            'test', 'test', 'test_rfid', MachineType.PICOBREW)
+        import_recipes_classic('test', 'test', 'test_rfid', MachineType.PICOBREW)
         mock_request.assert_called_once()
         recipe_mocker.assert_called_once()
-        recipe_mocker.assert_called_with(
-            recipe='#good stuff#', rfid='test_rfid')
+        recipe_mocker.assert_called_with(recipe='#good stuff#', rfid='test_rfid')

--- a/app/main/test_routes_frontend.py
+++ b/app/main/test_routes_frontend.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import pytest
 
 from server import app


### PR DESCRIPTION
- resume picoferm active session upon restart
- fix z recipe unique id (after importing you could in theory have multiple of the same `id`)
- various flake8 warnings (line size, unused imports, multiple lines, spaces on lines, etc)
- on initialization sessions would be eagerly created and replaced