### PR TITLE
include ability to download and delete all types of session files

### DIFF
--- a/app/static/js/brew_history.js
+++ b/app/static/js/brew_history.js
@@ -1,3 +1,7 @@
 function delete_file(filename){
     delete_server_file(filename, 'brew', 'brew_history');
 };
+
+function download_session(filename){
+    download_server_session(filename, 'brew');
+};

--- a/app/static/js/ferm_history.js
+++ b/app/static/js/ferm_history.js
@@ -1,3 +1,7 @@
 function delete_file(filename){
     delete_server_file(filename, 'ferm', 'ferm_history');
 };
+
+function download_session(filename){
+    download_server_session(filename, 'ferm');
+};

--- a/app/static/js/iSpindel_history.js
+++ b/app/static/js/iSpindel_history.js
@@ -1,0 +1,7 @@
+function delete_file(filename){
+    delete_server_file(filename, 'iSpindel', 'iSpindel_history');
+};
+
+function download_session(filename){
+    download_server_session(filename, 'iSpindel');
+};

--- a/app/static/js/server_management.js
+++ b/app/static/js/server_management.js
@@ -21,3 +21,7 @@ function delete_server_file(filename, type, redirectHref){
 		});
     }
 };
+
+function download_server_session(filename, type){
+    window.location = '/sessions/' + type + '/' + escape(filename);
+};

--- a/app/templates/brew_history.html
+++ b/app/templates/brew_history.html
@@ -14,6 +14,14 @@
       <h5 class="card-header" id="h_{{session.graph.chart_id}}">
         <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{session.graph.chart_id}}">
           {{session.name}} (Brewed {{session.date}}{% if session.alias is defined and session.alias|length %} with {{session.alias}}{% endif %}) 
+          <button class="btn btn-sm btn-primary float-right mr-5" type="button" id="bdownload_{{session.filename}}"
+              onclick="event.stopPropagation();event.preventDefault();download_session('{{session.filename}}');">
+              <i class="fas fa-download"></i>
+          </button>
+          <button class="btn btn-sm btn-danger float-right mr-3" type="button" id="bdelete_{{session.filename}}"
+            onclick="event.stopPropagation();event.preventDefault();delete_file('{{session.filepath}}');">
+            <i class="fas fa-trash"></i>
+          </button>
         </a>
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">

--- a/app/templates/ferm_history.html
+++ b/app/templates/ferm_history.html
@@ -14,6 +14,14 @@
       <h5 class="card-header" id="h_{{session.graph.chart_id}}">
         <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{session.graph.chart_id}}">
           {{session.name}} on {{session.date}}
+          <button class="btn btn-sm btn-primary float-right mr-5" type="button" id="bdownload_{{session.filename}}"
+              onclick="event.stopPropagation();event.preventDefault();download_session('{{session.filename}}');">
+              <i class="fas fa-download"></i>
+          </button>
+          <button class="btn btn-sm btn-danger float-right mr-3" type="button" id="bdelete_{{session.filename}}"
+            onclick="event.stopPropagation();event.preventDefault();delete_file('{{session.filepath}}');">
+            <i class="fas fa-trash"></i>
+          </button>  
         </a>
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">

--- a/app/templates/iSpindel_history.html
+++ b/app/templates/iSpindel_history.html
@@ -5,12 +5,23 @@
   <script src="static/js/highcharts/export-data.js"></script>
   <script src="static/js/highcharts/exporting.js"></script>
   <script src="static/js/highcharts/dark-unica.js"></script>
+  <script src="static/js/server_management.js"></script>
+  <script src="static/js/iSpindel_history.js"></script>
+  {% include "invalid_file.html" %}
   <div id="accordion">
     {% for session in sessions %}
     <div class="card bg-dark text-white-50">
       <h5 class="card-header" id="h_{{session.graph.chart_id}}">
         <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{session.graph.chart_id}}">
           {{session.name}} on {{session.date}}
+          <button class="btn btn-sm btn-primary float-right mr-5" type="button" id="bdownload_{{session.filename}}"
+              onclick="event.stopPropagation();event.preventDefault();download_session('{{session.filename}}');">
+              <i class="fas fa-download"></i>
+          </button>
+          <button class="btn btn-sm btn-danger float-right mr-3" type="button" id="bdelete_{{session.filename}}"
+            onclick="event.stopPropagation();event.preventDefault();delete_file('{{session.filepath}}');">
+            <i class="fas fa-trash"></i>
+          </button>  
         </a>
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">


### PR DESCRIPTION
**Features Included**
Backport invalid files and recover/restore session for **iSpindel** session types.
Add download and delete buttons to all session entries across the 3 different session types (`brew`, `ferm`, `iSpindel`)

![image](https://user-images.githubusercontent.com/2158627/102158476-89319a80-3e4f-11eb-82af-97b51a5242ad.png)
![image](https://user-images.githubusercontent.com/2158627/102158498-96e72000-3e4f-11eb-9f94-d3c4532f6a7f.png)
![image](https://user-images.githubusercontent.com/2158627/102158511-9c446a80-3e4f-11eb-8c72-5d8789f48e9c.png)
