### PR TITLE
refactor and fix usage of deprecated tabulator method

### DIFF
--- a/app/templates/recipe_list.html
+++ b/app/templates/recipe_list.html
@@ -32,12 +32,16 @@
                 <div class="table-recipe table-sm table-striped table-bordered table-light" id="t_{{recipe['id']}}">
                 </div>
                 <script>
-                    recipe_table['dataEdited'] = function (data) {
+                    function displayUnsavedState(data) {
                         document.getElementById("bsave_{{recipe['id']}}").style.display = "block";
                     }
-                    recipe_table['rowMoved'] = function (row) {
+                    
+                    recipe_table['cellEdited'] = displayUnsavedState
+                    recipe_table['rowAdded'] = displayUnsavedState
+                    recipe_table['rowDeleted'] = displayUnsavedState
+                    recipe_table['rowMoved'] = function(row) {
                         if (isRowMoved(row))
-                            document.getElementById("bsave_{{recipe['id']}}").style.display = "block";
+                            displayUnsavedState(row)
                     }
 
                     tables["{{recipe['id']}}"] = new Tabulator("#t_{{recipe['id']}}", recipe_table);


### PR DESCRIPTION
Tabultaor 4.8 deprecation notices made mention of `dataEdited` being renamed to `dataChanged`, but instead we should have been listening to these following events instead (as we programmatically calculate some of the data): `rowAdded`, `rowDeleted`, `rowMoved` (were already listening to that callback), and `cellEdited`.