### PR TITLE
eagerly create in memory session (not file bound)

### DIFF
--- a/app/main/routes_iSpindel_api.py
+++ b/app/main/routes_iSpindel_api.py
@@ -27,11 +27,8 @@ iSpindel_dataset_args = {
 # Process iSpindel Data: /API/iSpindel
 @main.route('/API/iSpindel', methods=['POST'])
 def process_iSpindel_data():
-    
     data = request.get_json()
-    
     uid = str(data['ID'])
-
     
     if uid not in active_iSpindel_sessions or active_iSpindel_sessions[uid].uninit:
         create_new_session(uid)
@@ -39,16 +36,21 @@ def process_iSpindel_data():
     time = ((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000)
     session_data = []
     log_data = ''
-    point = {'time': time,
-             'temp': data['temperature'],
-             'gravity': data['gravity'],
-            }
+    point = {
+        'time': time,
+        'temp': data['temperature'],
+        'gravity': data['gravity'],
+    }
+
     session_data.append(point)
     log_data += '\t{},\n'.format(json.dumps(point))
+    
     active_iSpindel_sessions[uid].data.extend(session_data)
     active_iSpindel_sessions[uid].voltage = str(data['battery']) + 'V'
+    
     graph_update = json.dumps({'voltage': data['battery'], 'data': session_data})
     socketio.emit('iSpindel_session_update|{}'.format(data['ID']), graph_update)
+    
     if (datetime.now().date() - active_iSpindel_sessions[uid].start_time.date()).days > 14:
         active_iSpindel_sessions[uid].file.write('{}\n]'.format(log_data[:-2]))
         active_iSpindel_sessions[uid].cleanup()

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -24,6 +24,9 @@ register_args = {
 @main.route('/API/pico/register')
 @use_args(register_args, location='querystring')
 def process_register(args):
+    uid = request.args['uid']
+    if uid not in active_brew_sessions:
+        active_brew_sessions[uid] = PicoBrewSession()
     return '#T#\r\n'
 
 

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -24,7 +24,7 @@ register_args = {
 @main.route('/API/pico/register')
 @use_args(register_args, location='querystring')
 def process_register(args):
-    uid = request.args['uid']
+    uid = args['uid']
     if uid not in active_brew_sessions:
         active_brew_sessions[uid] = PicoBrewSession()
     return '#T#\r\n'

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -23,6 +23,9 @@ ferm_registered_args = {
 @main.route('/API/PicoFerm/isRegistered')
 @use_args(ferm_registered_args, location='querystring')
 def process_ferm_registered(args):
+    uid = args['uid']
+    if uid not in active_ferm_sessions:
+        active_ferm_sessions[uid] = PicoFermSession()
     return '#1#'
 
 

--- a/app/main/routes_picostill_api.py
+++ b/app/main/routes_picostill_api.py
@@ -6,6 +6,8 @@ from random import seed
 from . import main
 from .config import picostill_firmware_path
 from .firmware import MachineType, firmware_filename, firmware_upgrade_required, minimum_firmware
+from .model import PicoStillSession
+from .session_parser import active_still_sessions
 
 
 arg_parser = FlaskParser()
@@ -31,6 +33,10 @@ picostill_check_firmware_args = {
 @main.route('/API/PicoStill/getFirmwareAddress', methods=['GET'])
 @use_args(picostill_check_firmware_args, location='querystring')
 def process_picostill_check_firmware(args):
+    uid = args['uid']
+    if uid not in active_still_sessions:
+        active_still_sessions[uid] = PicoStillSession()
+
     if firmware_upgrade_required(MachineType.PICOSTILL, args['version']):
         filename = firmware_filename(MachineType.PICOSTILL, minimum_firmware(MachineType.PICOSTILL))
         return '#http://picobrew.com/firmware/picostill/{}#'.format(filename)

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -171,11 +171,14 @@ def process_recipe_request(recipe_id):
 #                   "ZBackendError": 0
 #               }
 def process_zstate(args):
+    uid = request.args['token']
+    if uid not in active_brew_sessions:
+        active_brew_sessions[uid] = PicoBrewSession(MachineType.ZSERIES)
+    
     json = request.json
     update_required = firmware_upgrade_required(MachineType.ZSERIES, json['CurrentFirmware'])
     firmware_source = "https://picobrew.com/firmware/zseries/{}".format(firmware_filename(MachineType.ZSERIES, minimum_firmware(MachineType.ZSERIES)))
-    uid = request.args['token']
-
+    
     returnVal = {
         "Alias": zseries_alias(uid),
         "BoilerType": json['BoilerType'],       # TODO sometimes machine loses boilertype, need to resync with known state

--- a/app/main/routes_zymatic_api.py
+++ b/app/main/routes_zymatic_api.py
@@ -53,6 +53,10 @@ zymatic_firmware_check_args = {
 @main.route('/API/zymaticFirmwareCheck')
 @use_args(zymatic_firmware_check_args, location='querystring')
 def process_zymatic_firmware_check(args):
+    uid = args['machine']
+    if uid not in active_brew_sessions:
+        active_brew_sessions[uid] = PicoBrewSession(MachineType.ZYMATIC)
+
     return '\r\n#F#\r\n'
 
 


### PR DESCRIPTION
There are a few experiences that require "registering" the device (meaning there is an entry in the `active_*_sessions` variables). The only ways to eagerly create an entry here is:

1) by adding an alias in the config.yaml file
or
2) running a session (drain, rinse, clean, brew, etc)

Instead of relying on a session being run or configuration file being updated (either via the UI or file share) let's just eagerly create the session entry upon first request from the devices... this way they show up on index page immediately upon turning them on (upon a window refresh.. with the lack of a socketio publish for "new machine detected"). 

This unlocks those few experiences that require an actual active session or a machine "alias". Including the "waiting to brew" title on the index card as well as the product ID available in the import experiences for each device type. Aliasing isn't hard... but also isn't discoverable for new users so this allows one to import recipes before even knowing devices can and likely should have aliased names.