### PR TITLE
Issue #134 add start and stop fermentation buttons for picoferm device

### DIFF
--- a/app/main/model.py
+++ b/app/main/model.py
@@ -81,6 +81,7 @@ class PicoFermSession:
         self.file = None
         self.filepath = None
         self.alias = ''
+        self.active = False
         self.uninit = True
         self.voltage = '-'
         self.start_time = None

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -330,10 +330,12 @@ def update_device_session(uid, session_type):
             if session.file != None:
                 session.file.seek(0, os.SEEK_END)
                 if session.file.tell() > 0:
+                    # mark for completion and archive session file
                     session.file.seek(session.file.tell() - 1, os.SEEK_SET)  # Remove trailing , from last data set
                     session.file.write('\n]')
                     session.cleanup()
                 else:
+                    # delete empty session file (user started fermentation, but device never reported data)
                     os.remove(session.filepath)
         else:
             session.active = True

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -117,6 +117,8 @@ def process_log_ferm_dataset(args):
     socketio.emit('ferm_session_update|{}'.format(args['uid']), graph_update)
 
     ferm_days_elapsed = (datetime.now().date() - active_ferm_sessions[uid].start_time.date()).days
+
+    # end fermentation at 14d counter or when user specifies fermentation is complete
     if ferm_days_elapsed > 14 or (active_ferm_sessions[uid].uninit == False and active_ferm_sessions[uid].active == False):
         active_ferm_sessions[uid].file.write('{}\n]'.format(log_data[:-2]))
         active_ferm_sessions[uid].cleanup()

--- a/app/main/routes_picoferm_api.py
+++ b/app/main/routes_picoferm_api.py
@@ -71,10 +71,17 @@ get_ferm_state_args = {
 @main.route('/API/PicoFerm/getState')
 @use_args(get_ferm_state_args, location='querystring')
 def process_get_ferm_state(args):
-    if args['uid'] not in active_ferm_sessions:
-        create_new_session(args['uid'])
+    uid = args['uid']
+    if uid not in active_ferm_sessions:
+        active_ferm_sessions[uid] = PicoFermSession()
+    
     # TODO - Define logic on state - for now request information from PicoFerm
-    return '#10,0#'
+    session = active_ferm_sessions[uid]
+
+    if session.active == True:
+        return '#10,0#'
+    elif session.uninit or session.file == None:
+        return '#2,4'
 
 
 # LogDataSet: /API/PicoFerm/logDataSet?uid={UID}&rate={RATE}&voltage={VOLTAGE}&data={DATA}
@@ -108,12 +115,15 @@ def process_log_ferm_dataset(args):
     active_ferm_sessions[uid].voltage = str(args['voltage']) + 'V'
     graph_update = json.dumps({'voltage': args['voltage'], 'data': session_data})
     socketio.emit('ferm_session_update|{}'.format(args['uid']), graph_update)
-    if (datetime.now().date() - active_ferm_sessions[uid].start_time.date()).days > 14:
+
+    ferm_days_elapsed = (datetime.now().date() - active_ferm_sessions[uid].start_time.date()).days
+    if ferm_days_elapsed > 14 or (active_ferm_sessions[uid].uninit == False and active_ferm_sessions[uid].active == False):
         active_ferm_sessions[uid].file.write('{}\n]'.format(log_data[:-2]))
         active_ferm_sessions[uid].cleanup()
         # The server makes a determination when fermenting is done based on the datalog after it sends '2,4'
         return '#2,4#'
     else:
+        active_ferm_sessions[uid].active = True
         active_ferm_sessions[uid].file.write(log_data)
         active_ferm_sessions[uid].file.flush()
         # Errors like '10,16' send data but mark data error.

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -269,15 +269,17 @@ def restore_active_ferm_sessions():
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             ferm_session = load_ferm_session(file)
             # print('DEBUG: restore_active_sessions() {}'.format(ferm_session))
-            if ferm_session['uid'] not in active_ferm_sessions:
-                active_ferm_sessions[ferm_session['uid']] = []
+            uid = ferm_session['uid']
+            if uid not in active_ferm_sessions:
+                active_ferm_sessions[uid] = PicoFermSession()
 
-            session = PicoFermSession()
+            session = active_ferm_sessions[uid]
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
             session.alias = ferm_session['alias']
             session.start_time = ferm_session['date']
+            session.active = True
 
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -35,6 +35,12 @@ span.equipment-icon {
 span.equipment-icon img {
   width: 80%;
 }
+.fermentation-start {
+  margin-top: 10px;
+}
+.fermentation-stop {
+  margin-top: 10px;
+}
 form#f_new_recipe {
   width: 100%;
 }

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -15,9 +15,10 @@ function start_fermentation(uid) {
         contentType: "application/json; charset=UTF-8",
         success: function (data) {
             showAlert("Success!", "success");
+
+            $("#bstart_" + uid).toggleClass('d-block d-none')
+            $("#bstop_" + uid).toggleClass('d-block d-none')
             // setTimeout(function () { window.location.href = "/"; }, 2000);
-            $("#bstart_" + uid).removeClass('d-block').addClass('d-none');
-            $("#bstop_" + uid).removeClass('d-none').addClass('d-block');
         },
         error: function (request, status, error) {
             showAlert("Error: " + request.responseText, "danger");
@@ -39,8 +40,8 @@ function start_fermentation(uid) {
         contentType: "application/json; charset=UTF-8",
         success: function (data) {
             showAlert("Success!", "success");
-            $("#bstart_" + uid).removeClass('d-none').addClass('d-block');
-            $("#bstop_" + uid).removeClass('d-block').addClass('d-none');
+            $("#bstart_" + uid).toggleClass('d-block d-none')
+            $("#bstop_" + uid).toggleClass('d-block d-none')
 
             // until socketio publishes a new "empty" state just force a refresh (which will clear the graphs)
             setTimeout(function () { window.location.href = "/"; }, 2000);

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -1,0 +1,53 @@
+function showAlert(msg, type) {
+    $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");
+    $('#alert').show();
+}
+
+function start_fermentation(uid) {
+    var session = {}
+    session.active = true
+    $.ajax({
+        url: '/device/' + uid + '/sessions/ferm',
+        type: 'PUT',
+        data: JSON.stringify(session),
+        dataType: "json",
+        processData: false,
+        contentType: "application/json; charset=UTF-8",
+        success: function (data) {
+            showAlert("Success!", "success");
+            // setTimeout(function () { window.location.href = "/"; }, 2000);
+            $("#bstart_" + uid).removeClass('d-block').addClass('d-none');
+            $("#bstop_" + uid).removeClass('d-none').addClass('d-block');
+        },
+        error: function (request, status, error) {
+            showAlert("Error: " + request.responseText, "danger");
+            //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
+        },
+    });
+
+};
+
+ function stop_fermentation(uid) {
+    var session = {}
+    session.active = false
+    $.ajax({
+        url: '/device/' + uid + '/sessions/ferm',
+        type: 'PUT',
+        data: JSON.stringify(session),
+        dataType: "json",
+        processData: false,
+        contentType: "application/json; charset=UTF-8",
+        success: function (data) {
+            showAlert("Success!", "success");
+            $("#bstart_" + uid).removeClass('d-none').addClass('d-block');
+            $("#bstop_" + uid).removeClass('d-block').addClass('d-none');
+
+            // until socketio publishes a new "empty" state just force a refresh (which will clear the graphs)
+            setTimeout(function () { window.location.href = "/"; }, 2000);
+        },
+        error: function (request, status, error) {
+            showAlert("Error: " + request.responseText, "danger");
+            //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
+        },
+    });
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,6 +6,7 @@
   <script src="/static/js/highcharts/exporting.js"></script>
   <script src="/static/js/highcharts/dark-unica.js"></script>
   <script src="/static/js/socketio/socket.io.slim.js"></script>
+  <script src="/static/js/index.js"></script>
   <script>var socket = io.connect('//' + document.domain + ':' + location.port);</script>
   <div id="accordion">
     {% for brew_session in brew_sessions %}
@@ -43,6 +44,25 @@
             <img src="/static/img/picoferm.svg" atl="picoferm">
           </span>
           {% if ferm_session.alias is defined and ferm_session.alias|length %}{{ferm_session.alias}}{% else %}{{ferm_session.graph.chart_id}}{% endif %}
+          {% if ferm_session.active %}
+          <button class="fermentation-start d-none btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
+              onclick="event.stopPropagation();event.preventDefault();start_fermentation('{{ferm_session.uid}}');">
+              <i class="fas fa-play-circle"></i> Start Fermentation
+          </button>
+          <button class="fermentation-stop d-block btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
+              onclick="event.stopPropagation();event.preventDefault();stop_fermentation('{{ferm_session.uid}}');">
+              <i class="fas fa-stop-circle"></i> Stop Fermentation
+          </button>
+          {% else %}
+          <button class="fermentation-start d-block btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
+              onclick="event.stopPropagation();event.preventDefault();start_fermentation('{{ferm_session.uid}}');">
+              <i class="fas fa-play-circle"></i> Start Fermentation
+          </button>
+          <button class="fermentation-stop d-none btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
+              onclick="event.stopPropagation();event.preventDefault();stop_fermentation('{{ferm_session.uid}}');">
+              <i class="fas fa-stop-circle"></i> Stop Fermentation
+          </button>
+          {% endif %}
         </a>
       </h5>
       <div id="c_{{ferm_session.graph.chart_id}}" class="collapse show" aria-labelledby="h_{{ferm_session.graph.chart_id}}">


### PR DESCRIPTION
This changes the functionality of the PicoFerm device. Currently a session will be created when the device turns on and sends data to the server for the first time. Instead the server will "register" an empty session (in-memory) and only when the user marks "Start Fermentation" will data flow from the device to the server.

This is accomplished by switching between `10,0` (fermentation in progress) and `2,4` (do nothing) as the response codes to the device.

![image](https://user-images.githubusercontent.com/2158627/103560235-6c541a00-4e85-11eb-869f-ba69e7eaae19.png)


![image](https://user-images.githubusercontent.com/2158627/103560222-665e3900-4e85-11eb-94ba-5f50cc2f4afd.png)


I'm not sure what the intention of having a `2,16` (complete/stop sending data) to the PicoFerm actually does differently from just flipping to `2,4` as I have implemented here which is what we are sending at the 14d mark (should we remove that? display a count down in some other way? likely to do that later as a different PR regardless).