### PR TITLE
Issue #175 allow an active device (one with a session entry) to be aliased

### DIFF
--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -80,7 +80,8 @@ def handle_devices():
         alias = request.form['alias']
 
         # verify uid not already configured
-        if uid in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_still_sessions}:
+        if (uid in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_still_sessions} 
+                and active_session(uid).alias != ''):
             error = f'Product ID {uid} already configured'
             current_app.logger.error(error)
             return render_template('devices.html', error=error,
@@ -892,3 +893,16 @@ def increment_zseries_recipe_id():
         recipe_id += 1
 
     return recipe_id
+
+
+def active_session(uid):
+    if uid in active_brew_sessions:
+        return active_brew_sessions[uid]
+    elif uid in active_ferm_sessions:
+        return active_ferm_sessions[uid]
+    elif uid in active_iSpindel_sessions:
+        return active_iSpindel_sessions[uid]
+    elif uid in active_still_sessions:
+        return active_still_sessions[uid]
+    
+    return None


### PR DESCRIPTION
With the introduction of the eagerly created sessions this wasn't playing nicely with this conditional that wouldn't allow an alias created (not updated) for an existing device... this fixes that, though would still be a better overall user experience if the UID was an optional dropdown allowing any "detected" device to be more easily aliased. Maybe something to work on later.