### PR TITLE
Setup Multi-Variant Image Builds and Various Other Improvements

### DIFF
--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -656,7 +656,7 @@ def setup():
                     # regex \b marks a word boundary
                     ssid = payload['ssid']
                     subprocess.check_output(
-                        """sed -i 's/\bssid=.*/ssid="{}"/' {}""".format(ssid, wpa_files), shell=True)
+                        """sed -i 's/\\bssid=.*/ssid="{}"/' {}""".format(ssid, wpa_files), shell=True)
 
                     # set bssid (if set by user) in wpa_supplicant files
                     if 'bssid' in payload and payload['bssid']:
@@ -672,7 +672,7 @@ def setup():
                             """sudo sed -i 's/\(bssid=.*\)/# \\1/g' {}""".format(wpa_files), shell=True)
 
                     # set credentials (if set by user) in wpa_supplicant files
-                    if 'password' in payload and payload['password']:
+                    if 'password' in payload:
                         psk = payload['password']
                         subprocess.check_output(
                             """sed -i 's/psk=.*/psk="{}"/' {}""".format(psk, wpa_files), shell=True)

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -30,6 +30,18 @@
       </div>
     </div>
   </div>
+  {% if raspberrypi_image %}
+  <div class="row">
+    <div class="group col-sm-8">
+      <div class="card bg-dark text-white">
+        <h2>RaspberryPi Image Version</h2>
+        <pre class="text-white">
+          <code class="float-left">{{raspberrypi_image}}</code>
+        </pre>
+      </div>
+    </div>
+  </div>
+  {% endif %}
   <div class="row">
     <div class="group col-sm-8">
       <div class="card bg-dark text-white">
@@ -37,9 +49,8 @@
         <pre class="text-white">
           <code class="float-left">{{os_release}}</code>
         </pre>
-
         {% if raspberrypi_info %}
-          <h3>Raspberry PI Info</h2>
+          <h3>System Info</h2>
           <pre class="text-white">
             <code class="float-left">{{raspberrypi_info}}</code>
           </pre>

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -38,14 +38,18 @@
     </li>
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">System</a>
-      <div class="dropdown-menu dropdown-menu-right navbar-dark bg-dark" aria-labelledby="navbarDropdown">
-        <a class="dropdown-item nav-link bg-dark" href="/about">About</a>
-        <a class="dropdown-item nav-link bg-dark" href="/devices">Devices</a>
-        <a class="dropdown-item nav-link bg-dark" href="/setup">Setup/Configure</a>
-        <a class="dropdown-item nav-link bg-dark" href="/restart_server">Update/Restart Server</a>
-        <a class="dropdown-item nav-link bg-dark" href="/restart_system">Restart System (Pi)</a>
-        <a class="dropdown-item nav-link bg-dark" href="/shutdown_system">Shutdown System (Pi)</a>
-      </div>
+      <ul class="dropdown-menu dropdown-menu-right navbar-dark bg-dark" aria-labelledby="navbarDropdown">
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/about">About</a></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/devices">Devices</a></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/restart_server">Update/Restart Server</a></li>
+        {% if platform is defined and platform == "RaspberryPi" %}
+        <li role="separator bg-dark text-white" class="dropdown-divider"></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/setup">Setup/Configure (Pi)</a></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/logs">System Logs (Pi)</a></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/restart_system">Restart System (Pi)</a></li>
+        <li><a class="nav-link bg-dark dropdown-item text-white" href="/shutdown_system">Shutdown System (Pi)</a></li>
+        {% endif %}
+      </ul>
     </li>
   </ul>
 </nav>

--- a/scripts/pi/00-run-chroot.sh
+++ b/scripts/pi/00-run-chroot.sh
@@ -5,6 +5,12 @@ AP_IP="192.168.72.1"
 AP_SSID="PICOBREW"
 AP_PASS="PICOBREW"
 
+export IMG_NAME="PICOBREW_PICO"
+export IMG_RELEASE="beta6"
+export IMG_VARIANT="stable"
+# export IMG_VARIANT="latest"
+export GIT_SHA='$(git rev-parse --short HEAD)'
+
 # Enable root login
 #sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 
@@ -36,12 +42,17 @@ systemctl stop apt-daily-upgrade.timer
 systemctl disable apt-daily.timer
 systemctl disable apt-daily-upgrade.timer
 
-echo 'Revert to stable WiFi firmware...'
-dpkg --purge firmware-brcm80211
-wget http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt4_all.deb
-dpkg -i firmware-brcm80211_20190114-1+rpt4_all.deb
-apt-mark hold firmware-brcm80211
-rm firmware-brcm80211_20190114-1+rpt4_all.deb
+# revert 'stable' image to have rpt4 wireless firmware
+# build 'latest' image with the following lines commented out (required for Pi 400 - see https://github.com/chiefwigms/picobrew_pico/issues/182)
+if [[ ${IMG_VARIANT} == "stable" ]];
+then
+    echo 'Revert to stable WiFi firmware...'
+    dpkg --purge firmware-brcm80211
+    wget http://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt4_all.deb
+    dpkg -i firmware-brcm80211_20190114-1+rpt4_all.deb
+    apt-mark hold firmware-brcm80211
+    rm firmware-brcm80211_20190114-1+rpt4_all.deb
+fi
 
 echo 'Updating packages...'
 export DEBIAN_FRONTEND=noninteractive
@@ -356,7 +367,10 @@ then
   pip3 install -r requirements.txt
 fi
 
-echo 'Starting Picobrew Server...'
+source_sha=${GIT_SHA}
+rpi_image_version=${IMG_RELEASE}_${IMG_VARIANT}
+
+echo "Starting Picobrew Server (image: \$\{rpi_image_version\} ;source: \$\{source_sha\}) ..."
 python3 server.py 0.0.0.0 8080 &
 
 exit 0

--- a/scripts/pi/00-run-chroot.sh
+++ b/scripts/pi/00-run-chroot.sh
@@ -370,7 +370,7 @@ fi
 source_sha=${GIT_SHA}
 rpi_image_version=${IMG_RELEASE}_${IMG_VARIANT}
 
-echo "Starting Picobrew Server (image: \$\{rpi_image_version\} ;source: \$\{source_sha\}) ..."
+echo "Starting Picobrew Server (image: \${rpi_image_version}; source: \${source_sha}) ..."
 python3 server.py 0.0.0.0 8080 &
 
 exit 0

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -1,4 +1,4 @@
-sudo sh -c 'ifconfig wlan0 up && iwlist wlan0 scanning' | awk 'BEGIN{ FS="[:=]"; OFS = " " }
+sudo sh -c 'ifconfig wlan0 up && iwlist wlan0 scanning | iwlist wlan0 scanning last' | awk 'BEGIN{ FS="[:=]"; OFS = " " }
 /ESSID/{
     essid[c++]=$2
 }

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -1,4 +1,4 @@
-sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
+sudo ifconfig wlan0 up && sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
 /ESSID/{
     essid[c++]=$2
 }

--- a/scripts/pi/wifi_scan.sh
+++ b/scripts/pi/wifi_scan.sh
@@ -1,4 +1,4 @@
-sudo ifconfig wlan0 up && sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OFS = " " }
+sudo sh -c 'ifconfig wlan0 up && iwlist wlan0 scanning' | awk 'BEGIN{ FS="[:=]"; OFS = " " }
 /ESSID/{
     essid[c++]=$2
 }
@@ -14,7 +14,7 @@ sudo ifconfig wlan0 up && sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OF
     gsub(/.*Address: /,"")
     address[a++]=$0
 }
-/Encryption key/{ 
+/Encryption key/{
     encryption[d++]=$2
 }
 /Quality/{
@@ -22,7 +22,7 @@ sudo ifconfig wlan0 up && sudo iwlist wlan0 scanning | awk 'BEGIN{ FS="[:=]"; OF
     signal[b++]=$3
 }
 END {
-    for( c in essid ) { 
+    for( c in essid ) {
         print address[c],essid[c],frequency[c],channel[c],signal[c],encryption[c]
     }
 }'


### PR DESCRIPTION
In preparation for a beta6 release (with complete working offline wireless configuration) I also decided to add in a new concept to our releases known as "release variants". For not we have 2 (future we may have more 🤷‍♂️): latest (contains the latest of raspbian and all related firmware) and stable (contains a reverted rpt4 release of the WiFi firmware that supposedly adds stability???).

Other features included of importance:
- a standard `platform` (memorized at start up) template variable sent to conditionalize what shows up in the "system" navigation dropdown (hiding RaspberryPi only supported actions from non RaspberryPi deployments) as well as a new `render_templates_with_defaults` helper function... we need to make sure to always use this function moving forward
- image creation and startup (ie. `/etc/rc.local`) log changes to include a raspberry pi image and source sha in case server logs are needed for support we can tell exactly what the end user is running and where they came from (long as they aren't hacking around).
- `/logs` experience to download or load server logs into the browser
- formatting improvements for `system` navbar
- `/about` contains the raspberry pi image variant string (latest vs stable and beta6 vs beta7)
- wifi_scan.sh needed to also **up** the network interface before scanning can happen (for offline configuration support)
- use last wireless scan results if available and interface is "busy"
- fix escape of ssid word boundary command
