### PR TITLE
persist machine_type when recovering session

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,6 +94,7 @@ def create_app(debug=False):
                             if uid not in active_brew_sessions:
                                 active_brew_sessions[uid] = PicoBrewSession(mtype)
                             active_brew_sessions[uid].alias = aliases[mtype][uid]
+                            active_brew_sessions[uid].machine_type = mtype
                             active_brew_sessions[uid].is_pico = True if mtype in [MachineType.PICOBREW, MachineType.PICOBREW_C] else False
 
     return app

--- a/app/main/model.py
+++ b/app/main/model.py
@@ -140,6 +140,7 @@ class iSpindelSession:
         self.start_time = None
         self.data = []
 
+
 class SupportObject:
     def __init__(self):
         self.name = None

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -235,14 +235,12 @@ def restore_active_brew_sessions():
         for file in active_brew_session_files:
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             brew_session = load_brew_session(file)
-            uid = brew_session['uid']
-
             # print('DEBUG: restore_active_sessions() {}'.format(brew_session))
+            uid = brew_session['uid']
             if uid not in active_brew_sessions:
                 session = PicoBrewSession()
-            else:
-                session = active_brew_sessions[uid]
 
+            session = active_brew_sessions[uid]
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
@@ -266,7 +264,7 @@ def restore_active_ferm_sessions():
         active_ferm_session_files = list(ferm_active_sessions_path().glob(file_glob_pattern))
         for file in active_ferm_session_files:
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
-            ferm_session = load_ferm_session(file)
+            ferm_session = load_ferm_session(file)            
             # print('DEBUG: restore_active_sessions() {}'.format(ferm_session))
             uid = ferm_session['uid']
             if uid not in active_ferm_sessions:
@@ -276,13 +274,13 @@ def restore_active_ferm_sessions():
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.alias = ferm_session['alias']
             session.start_time = ferm_session['date']
             session.active = True
 
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']
-            active_ferm_sessions[ferm_session['uid']] = session
+
+            active_ferm_sessions[uid] = session
 
 
 def restore_active_iSpindel_sessions():
@@ -292,19 +290,20 @@ def restore_active_iSpindel_sessions():
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             ferm_session = load_iSpindel_session(file)
             # print('DEBUG: restore_active_sessions() {}'.format(ferm_session))
-            if ferm_session['uid'] not in active_iSpindel_sessions:
-                active_iSpindel_sessions[ferm_session['uid']] = []
+            uid = ferm_session['uid'
+            if uid not in active_iSpindel_sessions:
+                active_iSpindel_sessions[uid] = iSpindelSession()
 
-            session = iSpindelSession()
+            session = active_iSpindel_sessions[uid]
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.alias = ferm_session['alias']
             session.start_time = ferm_session['date']
-
+            
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']
-            active_iSpindel_sessions[ferm_session['uid']] = session
+
+            active_iSpindel_sessions[uid] = session
 
 
 def restore_active_sessions():

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -264,7 +264,7 @@ def restore_active_ferm_sessions():
         active_ferm_session_files = list(ferm_active_sessions_path().glob(file_glob_pattern))
         for file in active_ferm_session_files:
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
-            ferm_session = load_ferm_session(file)            
+            ferm_session = load_ferm_session(file)
             # print('DEBUG: restore_active_sessions() {}'.format(ferm_session))
             uid = ferm_session['uid']
             if uid not in active_ferm_sessions:
@@ -290,7 +290,7 @@ def restore_active_iSpindel_sessions():
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             ferm_session = load_iSpindel_session(file)
             # print('DEBUG: restore_active_sessions() {}'.format(ferm_session))
-            uid = ferm_session['uid'
+            uid = ferm_session['uid']
             if uid not in active_iSpindel_sessions:
                 active_iSpindel_sessions[uid] = iSpindelSession()
 
@@ -299,7 +299,7 @@ def restore_active_iSpindel_sessions():
             session.file.flush()
             session.filepath = file
             session.start_time = ferm_session['date']
-            
+
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']
 

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -235,31 +235,30 @@ def restore_active_brew_sessions():
         for file in active_brew_session_files:
             # print('DEBUG: restore_active_sessions() found {} as an active session'.format(file))
             brew_session = load_brew_session(file)
-            # print('DEBUG: restore_active_sessions() {}'.format(brew_session))
-            if brew_session['uid'] not in active_brew_sessions:
-                active_brew_sessions[brew_session['uid']] = []
+            uid = brew_session['uid']
 
-            session = PicoBrewSession()
+            # print('DEBUG: restore_active_sessions() {}'.format(brew_session))
+            if uid not in active_brew_sessions:
+                session = PicoBrewSession()
+            else:
+                session = active_brew_sessions[uid]
+
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.alias = brew_session['alias']
             session.created_at = brew_session['date']
             session.name = brew_session['name']
             session.type = brew_session['type']
             session.session = brew_session['session']                   # session guid
             session.id = -1                                             # session id (integer)
 
-            if 'machine_type' in brew_session:
-                session.machine_type = brew_session['machine_type']     # keep track of machine type of uid (if known)
-
             if 'recovery' in brew_session:
                 session.recovery = brew_session['recovery']             # find last step name
 
             # session.remaining_time = None
-            session.is_pico = brew_session['is_pico']
             session.data = brew_session['data']
-            active_brew_sessions[brew_session['uid']] = session
+
+            active_brew_sessions[uid] = session
 
 
 def restore_active_ferm_sessions():


### PR DESCRIPTION
In theory the problem is a single line (the one in __init__.py), but in the case of refactoring I also reorganized the session_parser.py code to allow for before or after loading of the initial server data context.