### PR TITLE
Issue 167 - mark session initialized for PicoFerm upon server boot

### DIFF
--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -300,8 +300,9 @@ def restore_active_iSpindel_sessions():
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.start_time = ferm_session['date']
+            session.start_time = datetime.strptime(ferm_session['date'], '%Y%m%d_%H%M%S')
 
+            session.uninit = False
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']
 

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from pathlib import Path
 
 from .config import brew_active_sessions_path, ferm_active_sessions_path, iSpindel_active_sessions_path
@@ -274,9 +275,10 @@ def restore_active_ferm_sessions():
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.start_time = ferm_session['date']
+            session.start_time = datetime.strptime(ferm_session['date'], '%Y%m%d_%H%M%S')
             session.active = True
 
+            session.uninit = False
             session.data = ferm_session['data']
             session.graph = ferm_session['graph']
 


### PR DESCRIPTION
Simply when restoring picoferm sessions the `session.uninit` wasn't being set so set this explicitly to `False`. Upon doing so it was immediately found that using the string stored as `session.start_time` would fail when being used for date math (to determine automatic end of session.. which maybe we remove anyways?) so converted that to a date object as well.