### PR TITLE
encode specific recipe name characters (' ' and '#')

### DIFF
--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -260,7 +260,11 @@ def create_new_session(uid, sesId, sesType):
         active_brew_sessions[uid].name = PICO_SESSION[sesType]
     else:
         active_brew_sessions[uid].name = 'Unknown Session ({})'.format(sesType)
-    active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, sesId, active_brew_sessions[uid].name.replace(' ', '_')))
+
+    # replace spaces and '#' with other character sequences
+    encoded_recipe = active_brew_sessions[uid].name.replace(' ', '_').replace("#", "%23")
+    filename = '{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, sesId, encoded_recipe)
+    active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath(filename)
     active_brew_sessions[uid].file = open(active_brew_sessions[uid].filepath, 'w')
     active_brew_sessions[uid].file.write('[')
 

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -405,11 +405,14 @@ def create_session(token, body):
     active_session.created_at = datetime.utcnow().isoformat()
     active_session.name = recipe.name if recipe else body['Name']
     active_session.type = body['SessionType']
+
+    # replace spaces and '#' with other character sequences
+    encoded_recipe = active_brew_sessions[uid].name.replace(' ', '_').replace("#", "%23")
     filename = '{0}#{1}#{2}#{3}#{4}.json'.format(
         datetime.now().strftime('%Y%m%d_%H%M%S'),
         uid,
         active_session.session,
-        active_session.name.replace(' ', '_'),
+        encoded_recipe,
         active_session.type)
     active_session.filepath = brew_active_sessions_path().joinpath(filename)
 

--- a/app/main/routes_zymatic_api.py
+++ b/app/main/routes_zymatic_api.py
@@ -158,7 +158,12 @@ def process_log_session(args):
             active_brew_sessions[uid] = PicoBrewSession(MachineType.ZYMATIC)
         active_brew_sessions[uid].session = uuid.uuid4().hex[:32]
         active_brew_sessions[uid].name = get_recipe_name_by_id(args['recipe'])
-        active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath('{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, active_brew_sessions[uid].name.replace(' ', '_')))
+
+        # replace spaces and '#' with other character sequences
+        encoded_recipe = active_brew_sessions[uid].name.replace(' ', '_').replace("#", "%23")
+        filename = '{0}#{1}#{2}#{3}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'), uid, active_brew_sessions[uid].session, encoded_recipe)
+        active_brew_sessions[uid].filepath = brew_active_sessions_path().joinpath(filename)
+        
         active_brew_sessions[uid].file = open(active_brew_sessions[uid].filepath, 'w')
         active_brew_sessions[uid].file.write('[')
         active_brew_sessions[uid].file.flush()

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -41,7 +41,8 @@ def load_brew_session(file):
     # 0 = Date, 1 = UID, 2 = RFID / Session GUID (guid), 3 = Session Name, 4 = Session Type (integer - z only)
     json_data = load_session_file(file)
 
-    name = info[3].replace('_', ' ')
+    # unencode the name section ('_' => ' ' ; '%23' -> '#')
+    name = info[3].replace('_', ' ').replace("%23", "#")
     step = ''
     chart_id = info[0] + '_' + info[2]
     alias = '' if info[1] not in active_brew_sessions else active_brew_sessions[info[1]].alias


### PR DESCRIPTION
This will prevent the issue that caused Issue #209 to occur, however won't fix any of these such session files that exist... users would need to manually change the recipe name's "#" in the session file to "%23" (the url encoding of "#").