### PR TITLE
attempt to recover from various invalid session forms... #209

### DIFF
--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -14,30 +14,38 @@ active_still_sessions = {}
 active_iSpindel_sessions = {}
 
 
-def load_session_file(file):
+def load_session_file(filename):
     json_data = {}
     try:
-        with open(file) as fp:
+        with open(filename) as fp:
             raw_data = fp.read().rstrip()
-            session = recover_incomplete_session(raw_data)
+            session = recover_incomplete_session(raw_data, filename)
             json_data = json.loads(session)
     except Exception as e:
-        current_app.logger.error("ERROR: An exception occurred parsing session file {}".format(file))
+        current_app.logger.error("An exception occurred parsing session file {}".format(filename))
         current_app.logger.error(e)
 
     return json_data
 
 
-def recover_incomplete_session(raw_data):
+def recover_incomplete_session(raw_data, filename):
+    # attempt to recover various incomplete session files
+    # (raw_data is already rstrip() so no trailing whitespace)
     recovered_session = raw_data
     if raw_data == None or raw_data.endswith('[') or raw_data == '':
-        # Recover from aborted session data file
+        # aborted session data file (containing no datalog entries)
         recovered_session = '[\n]'
-    elif raw_data.endswith(',\n]\n'):
-        # Recover from incomplete json data file
+    elif raw_data.endswith(',\n]'):
+        # closed trailing comma in datalog
+        recovered_session = raw_data[:-3] + '\n]\n'
+    elif raw_data.endswith(',\n\n]'):
+        # closed trailing comma and extra newline in datalog
         recovered_session = raw_data[:-4] + '\n]\n'
-    elif raw_data.endswith(',') or raw_data.endswith('}\n'):
-        # Recover from incomplete json data file
+    elif raw_data.endswith('}'):
+        # unclosed array of data entries
+        recovered_session = raw_data + '\n]\n'
+    elif raw_data.endswith(','):
+        # open trailing comma
         recovered_session = raw_data[:-1] + '\n]\n'
 
     return recovered_session

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -33,7 +33,10 @@ def recover_incomplete_session(raw_data):
     if raw_data == None or raw_data.endswith('[') or raw_data == '':
         # Recover from aborted session data file
         recovered_session = '[\n]'
-    elif raw_data.endswith(','):
+    elif raw_data.endswith(',\n]\n'):
+        # Recover from incomplete json data file
+        recovered_session = raw_data[:-4] + '\n]\n'
+    elif raw_data.endswith(',') or raw_data.endswith('}\n'):
         # Recover from incomplete json data file
         recovered_session = raw_data[:-1] + '\n]\n'
 


### PR DESCRIPTION
Regardless of fixing the way these files can get corrupted like this. Simply a brew session that misses a "complete" or otherwise isn't marked correctly as finished (existing or otherwise) we should look at recovering as many as we can (short of a power outage in the middle of writing a line in the file).

A long term fix for "invalid written JSON structure" can be found in https://github.com/chiefwigms/picobrew_pico/issues/216 and I'll defer fixing the "problem" until then. I've run this locally where on my system I have 6 different types of invalid sessions across the different types of devices and this fixes nearly all of them (short of the session files that have invalid names ie '#' in the filename, wrong date string, non integer, etc).

**current behavior with the new try/except handling from another PR**
invalid sessions (if the contents aren't parsable, but the filename is valid) show up as empty sessions now 
![image](https://user-images.githubusercontent.com/2158627/105629603-f1da4280-5e11-11eb-83af-cf093a0f53ec.png)


**proposed session recovery change**
with this proposed session recovery change (we should likely update again a bit later to just re-write the file if the session is recovered successfully...)
![image](https://user-images.githubusercontent.com/2158627/105629909-d07a5600-5e13-11eb-87d6-a1c3789b606e.png)
![image](https://user-images.githubusercontent.com/2158627/105630184-9ca03000-5e15-11eb-89d2-6472193e495c.png)

cc/ @Rudder2 I've tested in the above screenshot with your invalid RINSE and invalid HopHeads files here as well.