### PR TITLE
fix exponential notation device uid forcing to parse form input as strings on the python side

### DIFF
--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -30,8 +30,8 @@ def handle_devices():
     # register device alias and type
     if request.method == 'POST':
         mtype = MachineType(request.form['machine_type'])
-        uid = request.form['uid']
-        alias = request.form['alias']
+        uid = str(request.form['uid'])
+        alias = str(request.form['alias'])
 
         # verify uid not already configured
         if (uid in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_still_sessions} 


### PR DESCRIPTION
existing behavior:
![image](https://user-images.githubusercontent.com/2158627/105905055-fd836000-5fef-11eb-95d8-c535c285ab65.png)
![image](https://user-images.githubusercontent.com/2158627/105905081-05430480-5ff0-11eb-8608-06cd1e234fa2.png)
![image](https://user-images.githubusercontent.com/2158627/105905101-0ecc6c80-5ff0-11eb-812c-f98f5a2c4e2a.png)


fixed behavior:
![image](https://user-images.githubusercontent.com/2158627/105909850-15f67900-5ff6-11eb-8de5-325264bfa7b4.png)
![image](https://user-images.githubusercontent.com/2158627/105909902-20b10e00-5ff6-11eb-8eb2-1f566f843089.png)
