### PR TITLE
update iSpindel routes to support iSpindle, and other temperature related stuff

### DIFF
--- a/app/main/routes_iSpindel_api.py
+++ b/app/main/routes_iSpindel_api.py
@@ -9,37 +9,44 @@ from .. import socketio
 from .config import iSpindel_active_sessions_path
 from .model import iSpindelSession
 from .session_parser import active_iSpindel_sessions
+from .units import convert_temp
+
 
 arg_parser = FlaskParser()
 
 iSpindel_dataset_args = {
-    'name': fields.Str(required=True),           #device name
-    'ID' : fields.Int(required=True),            #random device ID
-    'angle' : fields.Float(required=True),       #device floatation angle
-    'temperature' : fields.Float(required=True), #device temperature
-    'temp_units' : fields.Str(required=True),    #temperature units in C or F
-    'battery' : fields.Float(required=True),     #device battery voltage
-    'gravity' : fields.Float(required=True),     #calculated specific gravity
-    'interval' : fields.Int(required=True),      #sampling interval in seconds
-    'RSSI' : fields.Int(required=True)           #RSSI of WiFi signal
+    'name': fields.Str(required=False),           #device name
+    'ID' : fields.Int(required=True),             #random device ID
+    'angle' : fields.Float(required=False),       #device floatation angle
+    'temperature' : fields.Float(required=True),  #device temperature
+    'temp_units' : fields.Str(required=True),     #temperature units in C or F
+    'battery' : fields.Float(required=True),      #device battery voltage
+    'gravity' : fields.Float(required=True),      #calculated specific gravity
+    'interval' : fields.Int(required=False),      #sampling interval in seconds
+    'RSSI' : fields.Int(required=False)           #RSSI of WiFi signal
 }
 
-# Process iSpindel Data: /API/iSpindel
+# Process iSpindel Data: /API/iSpindel or /API/iSpindle
+@main.route('/API/iSpindle', methods=['POST'])
 @main.route('/API/iSpindel', methods=['POST'])
-def process_iSpindel_data():
-    data = request.get_json()
+@use_args(iSpindel_dataset_args)
+def process_iSpindel_data(data):
     uid = str(data['ID'])
     
-    if (uid not in active_iSpindel_sessions or active_iSpindel_sessions[uid].uninit) and active_iSpindel_sessions[uid].active:
-        create_new_session(uid)
+    if uid not in active_iSpindel_sessions:
+        active_iSpindel_sessions[uid] = iSpindelSession()
 
     if active_iSpindel_sessions[uid].active:
+        # initialize session and session files
+        if active_iSpindel_sessions[uid].uninit:
+            create_new_session(uid)
+
         time = ((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000)
         session_data = []
         log_data = ''
         point = {
             'time': time,
-            'temp': data['temperature'],
+            'temp': data['temperature'] if data['temp_units'] == 'F' else convert_temp(data['temperature'], 'F'),
             'gravity': data['gravity'],
         }
 
@@ -65,7 +72,8 @@ def process_iSpindel_data():
             return('', 200)
     else:
         return('', 200)
-    
+
+
 # -------- Utility --------
 def create_new_session(uid):
     if uid not in active_iSpindel_sessions:

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -15,6 +15,7 @@ from .firmware import firmware_filename, firmware_upgrade_required, minimum_firm
 from .model import PicoBrewSession
 from .routes_frontend import get_zseries_recipes, load_brew_sessions
 from .session_parser import active_brew_sessions
+from .units import convert_temp
 
 
 arg_parser = FlaskParser()
@@ -46,12 +47,6 @@ class ZProgramId(int, Enum):
     BEER_OR_COFFEE = 24
     STILL = 26
     CHILL = 27
-
-
-def convertTemp(temp: float, units: str):
-    if units.upper() == 'F':
-        return (temp * 9/5) + 32  # convert celcius to fahrenheit
-    return (temp - 32) * 5/9  # convert fahrenheit to celcius
 
 
 # Get Firmware: /firmware/zseries/<version>
@@ -492,11 +487,11 @@ def update_session_log(token, body):
         'timeLeft': body['SecondsRemaining'],
         'step': body['StepName'],
         # temperatures from Z are in celsius vs prior device series
-        'target': convertTemp(body['TargetTemp'], 'F'),
-        'ambient': convertTemp(body['AmbientTemp'], 'F'),
-        'drain': convertTemp(body['DrainTemp'], 'F'),
-        'wort': convertTemp(body['WortTemp'], 'F'),
-        'therm': convertTemp(body['ThermoBlockTemp'], 'F'),
+        'target': convert_temp(body['TargetTemp'], 'F'),
+        'ambient': convert_temp(body['AmbientTemp'], 'F'),
+        'drain': convert_temp(body['DrainTemp'], 'F'),
+        'wort': convert_temp(body['WortTemp'], 'F'),
+        'therm': convert_temp(body['ThermoBlockTemp'], 'F'),
         'recovery': body['StepName'],
         'position': body['ValvePosition']
     }

--- a/app/main/units.py
+++ b/app/main/units.py
@@ -1,0 +1,9 @@
+# convert temperature between F and C
+def convert_temp(temp: float, units: str):
+    converted_temp = temp
+    if units.upper() == 'F':
+        converted_temp = (temp * 9/5) + 32  # convert celcius to fahrenheit
+    else:
+        converted_temp = (temp - 32) * 5/9  # convert fahrenheit to celcius
+
+    return round(converted_temp, 2)

--- a/app/static/js/convert_units.js
+++ b/app/static/js/convert_units.js
@@ -1,9 +1,12 @@
 // utility function to convert temperature units
 function convert_temperature(temp, units) {
+    let converted_temp;
     if (units.toLowerCase() == 'imperial') {
-        return (temp * 9 / 5) + 32  // convert celcius to fahrenheit
+        converted_temp = (temp * 9 / 5) + 32;  // convert celcius to fahrenheit
+    } else {
+        converted_temp = (temp - 32) * 5 / 9;  // convert fahrenheit to celcius
     }
-    return (temp - 32) * 5 / 9  // convert fahrenheit to celcius
+    return Number((converted_temp).toFixed(2));
 }
 
 function temperature_editor(cell, onRendered, success, cancel, editorParams) {


### PR DESCRIPTION
@BuckoWA take a look at the changes I made to iSpindel. Specifically related to when `create_new_session` is called, since that creates a file. Prior to this change if you setup an iSpindle a file is created with '[' and then if you power cycle the server fermentation is marked as active due to there being a file. This is now aligned with the picoferm where you have to click `START` in order to get a file created and start monitoring fermentation progress. I also ended with an exception the first time logging from the iSpindel (using Postman) exception follows, but in changing around that conditional I've resolved that problem.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.9/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.9/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/tmack/dev/projects/trevormack/picobrew_pico/app/main/routes_iSpindel_api.py", line 34, in process_iSpindel_data
    if (uid not in active_iSpindel_sessions or active_iSpindel_sessions[uid].uninit) and active_iSpindel_sessions[uid].active:
KeyError: '1234567890'
```

Also noticed that the argument structure of the JSON payload was setup as an args, but never linked to the method so I did that while marking specific components optional as the server doesn't use them (`name`, `angle`, `interval`, and `RSSI`).

In seeing this argument structure it looks like someone could setup an iSpindel in Celsius and just for consistency reasons I have not converted the temperature readings when that is the case back into Fahrenheit (since that is what our frontend assumes wrongfully so...).