### PR TITLE
upload and new recipe actions, session history changes and shared graphing tooltip

### DIFF
--- a/app/main/recipe_parser.py
+++ b/app/main/recipe_parser.py
@@ -50,6 +50,8 @@ class ZymaticRecipe():
                 step.temperature = 70 if 'temperature' not in recipe_step else int(recipe_step['temperature'])
                 step.step_time = 0 if 'step_time' not in recipe_step else int(recipe_step['step_time'])
                 step.location = recipe_step.get('location', 'PassThru') or 'PassThru'
+                if step.location not in ZYMATIC_LOCATION:
+                    raise ValueError(f'step.location provided {step.location} is not supported by Zymatic machine type')
                 step.drain_time = 0 if 'drain_time' not in recipe_step else int(recipe_step['drain_time'])
                 self.steps.append(step)
 
@@ -77,6 +79,8 @@ class ZymaticRecipe():
             step.temperature = 70 if 'temperature' not in s else int(s['temperature'])
             step.step_time = 0 if 'step_time' not in s else int(s['step_time'])
             step.location = s.get('location', 'PassThru') or 'PassThru'
+            if step.location not in ZYMATIC_LOCATION:
+                raise ValueError(f'step.location provided {step.location} is not supported by Zymatic machine type')
             step.drain_time = 0 if 'drain_time' not in s else int(s['drain_time'])
             self.steps.append(step)
         updated_recipe = json.loads(json.dumps(self, default=lambda r: r.__dict__))
@@ -161,6 +165,8 @@ class ZSeriesRecipe():
                 step.location = recipe_step.get('location', 'PassThru') or 'PassThru'
                 if step.location == 'PassThrough':
                     step.location = 'PassThru'
+                if step.location not in ZSERIES_LOCATION:
+                    raise ValueError(f'step.location provided {step.location} is not supported by ZSeries machine type')
                 step.drain_time = 0 if 'drain_time' not in recipe_step else int(recipe_step['drain_time'])
                 self.steps.append(step)
 
@@ -192,6 +198,8 @@ class ZSeriesRecipe():
             step.location = s.get('location', 'PassThru') or 'PassThru'
             if step.location == 'PassThrough':
                 step.location = 'PassThru'
+            if step.location not in ZSERIES_LOCATION:
+                raise ValueError(f'step.location provided {step.location} is not supported by ZSeries machine type')
             step.drain_time = 0 if 'drain_time' not in s else int(s['drain_time'])
             self.steps.append(step)
         updated_recipe = json.loads(json.dumps(self, default=lambda r: r.__dict__))
@@ -293,6 +301,8 @@ class PicoBrewRecipe():
                 step = PicoBrewRecipeStep()
                 step.name = recipe_step.get('name', 'Empty Step') or 'Empty Step'
                 step.location = recipe_step.get('location', 'PassThru') or 'PassThru'
+                if step.location not in PICO_LOCATION:
+                    raise ValueError(f'step.location provided {step.location} is not supported by Pico machine type')
                 step.temperature = 70 if 'temperature' not in recipe_step else int(recipe_step['temperature'])
                 step.step_time = 0 if 'step_time' not in recipe_step else int(recipe_step['step_time'])
                 step.drain_time = 0 if 'drain_time' not in recipe_step else int(recipe_step['drain_time'])
@@ -327,6 +337,8 @@ class PicoBrewRecipe():
             step = PicoBrewRecipeStep()
             step.name = s.get('name', 'Empty Step') or 'Empty Step'
             step.location = s.get('location', 'PassThru') or 'PassThru'
+            if step.location not in PICO_LOCATION:
+                raise ValueError(f'step.location provided {step.location} is not supported by Pico machine type')
             step.temperature = 70 if 'temperature' not in s else int(s['temperature'])
             step.step_time = 0 if 'step_time' not in s else int(s['step_time'])
             step.drain_time = 0 if 'drain_time' not in s else int(s['drain_time'])

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -5,7 +5,7 @@ import requests
 import socket
 import uuid
 from ruamel.yaml import YAML
-from flask import current_app, flash, make_response, redirect, request, send_file, escape
+from flask import current_app, make_response, request, send_file, escape
 from pathlib import Path
 from os import path
 from werkzeug.utils import secure_filename

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -68,7 +68,7 @@ def load_brew_session(file):
         session_type = int(info[4])
 
     session = {
-        'date': info[0],
+        'date': datetime.strptime(info[0], '%Y%m%d_%H%M%S'),
         'name': name,
         'filename': Path(file).name,
         'filepath': Path(file),
@@ -168,7 +168,7 @@ def load_ferm_session(file):
         'filename': Path(file).name,
         'filepath': Path(file),
         'alias': alias,
-        'date': info[0],
+        'date': datetime.strptime(info[0], '%Y%m%d_%H%M%S'),
         'name': name,  # should change to brew/user defined session name
         'data': json_data,
         'graph': get_ferm_graph_data(chart_id, None, json_data)
@@ -292,7 +292,7 @@ def restore_active_ferm_sessions():
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.start_time = datetime.strptime(ferm_session['date'], '%Y%m%d_%H%M%S')
+            session.start_time = ferm_session['date']
             session.active = True
 
             session.uninit = False
@@ -317,7 +317,7 @@ def restore_active_iSpindel_sessions():
             session.file = open(file, 'a')
             session.file.flush()
             session.filepath = file
-            session.start_time = datetime.strptime(iSpindel_session['date'], '%Y%m%d_%H%M%S')
+            session.start_time = iSpindel_session['date']
             session.active = True
 
             session.uninit = False

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,4 +1,4 @@
-#options {
+#options, #recipe_actions{
   margin-bottom: 25px;
   text-align: right;
 }

--- a/app/static/js/brew_graph.js
+++ b/app/static/js/brew_graph.js
@@ -28,6 +28,20 @@ Highcharts.chart(graph_data.chart_id, {
 
   subtitle: graph_data.subtitle,
 
+  tooltip: {
+    formatter: function() {
+        var s = '<b>'+ Highcharts.dateFormat('%A, %b %e %k:%M:%S.%L', // Friday, Jan ## ##:##:##.####
+          new Date(this.x)) +'</b>';
+
+        $.each(this.points, function(i, point) {
+            s += '<br/><span style="color:' + point.color + '">\u25CF</span> ' + point.series.name + ': ' + point.y;
+        });
+
+        return s;
+    },
+    shared: true
+  },
+
   xAxis: {
     type: 'datetime',
     title: {

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -47,6 +47,10 @@ Highcharts.chart(graph_data.chart_id, {
 
   subtitle: graph_data.subtitle,
 
+  tooltip: {
+    shared: true
+  },
+
   xAxis: {
     type: 'datetime',
     title: {

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -48,6 +48,16 @@ Highcharts.chart(graph_data.chart_id, {
   subtitle: graph_data.subtitle,
 
   tooltip: {
+    formatter: function() {
+        var s = '<b>'+ Highcharts.dateFormat('%A, %b %e %k:%M:%S.%L', // Friday, Jan ## ##:##:##.####
+          new Date(this.x)) +'</b>';
+
+        $.each(this.points, function(i, point) {
+            s += '<br/><span style="color:' + point.color + '">\u25CF</span> ' + point.series.name + ': ' + point.y;
+        });
+
+        return s;
+    },
     shared: true
   },
 

--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -301,15 +301,15 @@ $(document).ready(function () {
                 setTimeout(function () { window.location.href = "pico_recipes"; }, 2000);
             },
             error: function (request, status, error) {
-                showAlert("Error: " + request.responseText, "danger");
+                showAlert(`Error: ${request.responseText}`, "danger");
                 //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
             },
         });
     });
-    function showAlert(msg, type) {
-        $('#alert').html("<div class='w-75 alert text-center alert-" + type + "'>" + msg + "</div>");
-        $('#alert').show();
-    }
+
+    $('#upload_recipe_file').on('change', function () {
+        upload_recipe_file('picobrew', $(this).prop('files')[0], 'pico_recipes');
+    });
 });
 
 function update_recipe(recipe_id) {
@@ -350,13 +350,13 @@ function edit_recipe(recipe_id) {
 function download_recipe(recipe_id, recipe_name) {
     var table = Tabulator.prototype.findTable("#t_" + recipe_id)[0];
     if (table) {
-        window.location = '/recipes/picobrew/' + recipe_id + '/' + unescapeHtml(recipe_name) + '.json';
+        window.location = `/recipes/picobrew/${recipe_id}/${unescapeHtml(recipe_name)}.json`;
     }
 };
 
 function clone_recipe(recipe) {
     recipe.id = ''
-    recipe.name = recipe.name + " (copy " + Math.floor((Math.random() * 100) + 1) + ")";
+    recipe.name = `${recipe.name} (copy ${Math.floor((Math.random() * 100) + 1)})`;
     $.ajax({
         url: 'new_pico_recipe',
         type: 'POST',
@@ -369,7 +369,7 @@ function clone_recipe(recipe) {
             setTimeout(function () { window.location.href = "pico_recipes"; }, 2000);
         },
         error: function (request, status, error) {
-            showAlert("Error: " + request.responseText, "danger")
+            showAlert(`Error: ${request.responseText}`, "danger")
             //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
         },
     });
@@ -389,7 +389,7 @@ function delete_recipe(recipe_id) {
                 setTimeout(function () { window.location.href = "pico_recipes"; }, 2000);
             },
             error: function (request, status, error) {
-                //showAlert("Error: " + request.responseText, "danger");
+                //showAlert(`Error: ${request.responseText}`, "danger");
                 //setTimeout(function () { window.location.href = "pico_recipes";}, 2000);
             },
         });

--- a/app/static/js/server_management.js
+++ b/app/static/js/server_management.js
@@ -25,3 +25,35 @@ function delete_server_file(filename, type, redirectHref){
 function download_server_session(filename, type){
     window.location = '/sessions/' + type + '/' + escape(filename);
 };
+
+function upload_recipe_file(machineType, file, redirectUrl) {
+    // error due to unsupported file type
+    if(!file.name.endsWith(".json")) {
+        showAlert(`Error: ${file.name} is an unsupported filetype.`, "danger");
+        return;
+    }
+
+    let formData = new FormData();
+    formData.append("recipe", file);
+
+    fetch(`/recipes/${machineType}`, {
+        method: 'POST',
+        body: formData
+    })
+    .then(result => {
+        if (!result.ok) {
+            // make the promise be rejected if we didn't get a 2xx response
+            throw new Error(`Server Failed with ${result.status} response code`);
+        }
+        return result.text()
+    })
+    .then(result => {
+        console.log('Success: ', result);
+        showAlert("Success!", "success");
+        setTimeout(function () { window.location.href = redirectUrl; }, 2000);
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        showAlert(`Error: upload of recipe failed<br/>${error}`, "danger");
+    });
+}

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -243,6 +243,10 @@ $(document).ready(function () {
             },
         });
     });
+
+    $('#upload_recipe_file').on('change', function () {
+        upload_recipe_file('zseries', $(this).prop('files')[0], 'zseries_recipes');
+    });
 });
 
 function update_recipe(recipe_id) {

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -238,6 +238,10 @@ $(document).ready(function () {
             },
         });
     });
+
+    $('#upload_recipe_file').on('change', function () {
+        upload_recipe_file('zymatic', $(this).prop('files')[0], 'zymatic_recipes');
+    });
 });
 
 function update_recipe(recipe_id) {

--- a/app/templates/brew_history.html
+++ b/app/templates/brew_history.html
@@ -26,6 +26,23 @@
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">
         <div class="card-body">
+          <div id="d_{{session.graph.chart_id}}" class="text-white">
+            <div class="row">
+              <div class="col-sm">
+                <div class="text-white-50">Machine</div>
+                <div>{% if session.alias is defined and session.alias|length %}{{session.alias}}{% else %}{{session.uid}}{% endif %}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Started</div>
+                <div>{{session.date.strftime('%A, %b %e %Y %k:%M:%S')}}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Completed</div>
+                <div>Unknown</div>
+              </div>
+            </div>
+            <div class="row">&nbsp;</div>
+          </div>
           <div id="{{session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{session.graph|tojson}};</script>
           <script src="/static/js/brew_graph.js"></script>

--- a/app/templates/brew_history.html
+++ b/app/templates/brew_history.html
@@ -30,11 +30,11 @@
             <div class="row">
               <div class="col-sm">
                 <div class="text-white-50">Machine</div>
-                <div>{% if session.alias is defined and session.alias|length %}{{session.alias}}{% else %}{{session.uid}}{% endif %}</div>
+                <div>{% if session.alias is defined and session.alias|length %}{{session.alias}} ({{session.uid}}){% else %}{{session.uid}}{% endif %}</div>
               </div>
               <div class="col-sm">
                 <div class="text-white-50">Date Started</div>
-                <div>{{session.date.strftime('%A, %b %e %Y %k:%M:%S')}}</div>
+                <div>{{session.date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
               </div>
               <div class="col-sm">
                 <div class="text-white-50">Date Completed</div>

--- a/app/templates/pico_recipes.html
+++ b/app/templates/pico_recipes.html
@@ -6,6 +6,9 @@
 <script src="/static/js/pico_recipe.js"></script>
 <script>var tables = {};</script>
 {% include "units_selector.html" %}
+{% with machine_type='pico' %}
+    {% include "recipe_actions.html" %}
+{% endwith %}
 {% include "invalid_file.html" %}
 <br /><br /><br />
 {% include "recipe_list.html" %}

--- a/app/templates/recipe_actions.html
+++ b/app/templates/recipe_actions.html
@@ -1,0 +1,9 @@
+<div id="recipe_actions" class="actions">
+    <a class="btn btn-sm btn-success mr-3" href="/new_{{machine_type}}_recipe" role="button">
+        <i class="fas fa-plus"></i> New Recipe
+    </a>
+    <div id="bupload_recipe" class="file btn btn-sm btn-primary" style="position: relative;">
+        <i class="fas fa-upload"></i> Upload Recipe
+        <input id="upload_recipe_file" type="file" name="file" style="position: absolute; opacity: 0; right: 0; left: 0;"/>
+    </div>
+</div>

--- a/app/templates/zseries_recipes.html
+++ b/app/templates/zseries_recipes.html
@@ -5,6 +5,9 @@
 <script src="/static/js/zseries_recipe.js"></script>
 <script>var tables = {};</script>
 {% include "units_selector.html" %}
+{% with machine_type='zseries' %}
+    {% include "recipe_actions.html" %}
+{% endwith %}
 {% include "invalid_file.html" %}
 <br /><br /><br />
 {% include "recipe_list.html" %}

--- a/app/templates/zymatic_recipes.html
+++ b/app/templates/zymatic_recipes.html
@@ -5,6 +5,9 @@
 <script src="/static/js/zymatic_recipe.js"></script>
 <script>var tables = {};</script>
 {% include "units_selector.html" %}
+{% with machine_type='zymatic' %}
+    {% include "recipe_actions.html" %}
+{% endwith %}
 {% include "invalid_file.html" %}
 <br /><br /><br />
 {% include "recipe_list.html" %}


### PR DESCRIPTION
Few things changed in this PR:

First and foremost is a new "create" and "upload" recipe button on the recipe library experience:
![recipe-upload](https://user-images.githubusercontent.com/2158627/106973123-358d5000-6720-11eb-9281-d38c5a8d1e1a.gif)

Secondly is a change to the session view to extract metadata from the session into the experience:
![image](https://user-images.githubusercontent.com/2158627/106973461-e98edb00-6720-11eb-90d0-e5d9777a115d.png)
![image](https://user-images.githubusercontent.com/2158627/106973496-f01d5280-6720-11eb-8a48-6b10cb62a472.png)

For the date parsing I switched around to parse the data at the same time we parse the session file and pull parsed date along vs parsing it later.

Thirdly I've been hearing that folks have copied pico files into zymatic and zseries and being confused why they don't work. So added a sanity check that the locations of a particular recipe match to the known locations supported/expected by the machine type. Raising exceptions to report the recipe as "invalid" in the UI when this happens. Likely with the first change above "upload" this will likely become more common... as people just upload random json files that aren't intended for that machine type (same as what is possible now via SMB)

Lastly I modified the highcharts for brewing graphs to use a `shared` and custom formatted tooltip to combined all temperature measurements together into a single tooltip. It is much easier now on mobile to see specific temperature differences (ie. detecting or visually seeing overheat disparities)
![image](https://user-images.githubusercontent.com/2158627/106973989-ee07c380-6721-11eb-9bbc-74fb33b4987c.png)
