### PR TITLE
conditionalize the server scripts in /setup experience for non raspberrypi setups

### DIFF
--- a/app/main/routes_server.py
+++ b/app/main/routes_server.py
@@ -15,7 +15,7 @@ from os import path
 
 from . import main
 from .config import base_path
-from .frontend_common import render_template_with_defaults, system_info
+from .frontend_common import platform, render_template_with_defaults, system_info
 
 
 # -------- Routes --------
@@ -35,13 +35,19 @@ def restart_server():
 
 @main.route('/restart_system')
 def restart_system():
+    if platform() != "RaspberryPi":
+        return '', 404
+    
     os.system('shutdown -r now')
     # TODO: redirect to a page with alert of restart
     return redirect('/')
-
+    
 
 @main.route('/shutdown_system')
 def shutdown_system():
+    if platform() != "RaspberryPi":
+        return '', 404
+    
     os.system('shutdown -h now')
     # TODO: redirect to a page with alert of shutdown
     return redirect('/')
@@ -49,11 +55,17 @@ def shutdown_system():
 
 @main.route('/logs')
 def view_logs():
+    if platform() != "RaspberryPi":
+        return '', 404
+    
     return render_template_with_defaults('logs.html')
-
+    
 
 @main.route('/logs/<log_type>.log')
 def download_logs(log_type):
+    if platform() != "RaspberryPi":
+        return '', 404
+
     try:
         filename = ""
         if log_type == 'nginx.access':
@@ -99,6 +111,9 @@ def available_networks():
 @main.route('/setup', methods=['GET', 'POST'])
 def setup():
     if request.method == 'POST':
+        if platform() != "RaspberryPi":
+            return '', 404
+    
         payload = request.get_json()
 
         if 'hostname' in payload:
@@ -209,20 +224,25 @@ def setup():
             current_app.logger.error("ERROR: unsupported payload received %s".format(payload))
             return 'Invalid Setup Payload Received - Setup Failed!', 418
     else:
-        return render_template_with_defaults('setup.html',
-            hostname=hostname(),
-            ap0=accesspoint_credentials(),
-            wireless_credentials=wireless_credentials(),
-            available_networks=available_networks())
+        if platform() == "RaspberryPi":
+            return render_template_with_defaults('setup.html',
+                hostname=hostname(),
+                ap0=accesspoint_credentials(),
+                wireless_credentials=wireless_credentials(),
+                available_networks=available_networks())
+        else:
+            return render_template_with_defaults('setup.html',
+                hostname=hostname(),
+                ap0=None,
+                wireless_credentials=None,
+                available_networks=None)
 
 
 def hostname():
     try:
-        subprocess.check_output("more /etc/hostname", shell=True)
-        return subprocess.check_output("hostname", shell=True).decode("utf-8").strip()
+        return subprocess.check_output("more /etc/hostname || hostname", shell=True).decode("utf-8").strip()
     except:
         current_app.logger.warn("current device doesn't support hostname changes")
-
     return None
 
 

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
   <script src="/static/js/setup.js"></script>
+  {% if available_networks %}
   <form id="f_wireless_setup">
     <div class="text-white">
       <h4>Setup Wireless Interface</h4>
@@ -40,6 +41,7 @@
       </div>
     </div>
   </form>
+  {% endif %}
 
   {% if ap0 %}
   <br/>
@@ -78,24 +80,31 @@
   <br/>
   <form id="f_hostname_setup">
     <div class="text-white">
-      <h4>Setup Hostname</h4>
-      <p>If you want to have a custom hostname for your server you can customize this below. This is useful if you have multiple raspberrypi devices and/or want to have a more memoriable or meaningful hostname for your configuration.</p>
+      <h4>{% if platform == "RaspberryPi" %} Setup {% endif %}Hostname</h4>
+      {% if platform == "RaspberryPi" %}
+        <p>If you want to have a custom hostname for your server you can customize this below. This is useful if you have multiple raspberrypi devices and/or want to have a more memoriable or meaningful hostname for your configuration.</p>
+      {% endif %}
     </div>
     <div class="form-row">
       <div class="form-group col-sm-5">
-        <input type="text" class="form-control form-control-sm" id="hostname" value="{{hostname}}" placeholder="Hostname">
+        <input type="text" class="form-control form-control-sm" id="hostname" value="{{hostname}}" placeholder="Hostname" {% if platform != "RaspberryPi" %}disabled{% endif %}>
         <small id="hostname_HelpBlock" class="form-text text-muted">
           Name of device on the network
         </small>
         <br/>
+        {% if platform == "RaspberryPi" %}
         <button class="w-75 btn btn-sm btn-secondary btn-block" type="button" id="b_save_hostname_setup">Save</button>
         <small id="b_save_hostname_setup_HelpBlock" class="form-text text-warning">
           Changing hostname will restart the RaspberryPi and will be unavailable for a small period of time.
         </small>
-        
+        {% endif %}
       </div>
     </div>
   </form>
+  {% endif %}
+
+  {% if hostname == None and ap0 == None and available_networks == None %}
+  <p>Setup isn't supported on this installation type at this time.</p>
   {% endif %}
   
   <br/>


### PR DESCRIPTION
Better to have 
![image](https://user-images.githubusercontent.com/2158627/107052852-2350f780-679c-11eb-8932-bb0164891ba3.png)

than an internal server error.


