### PR TITLE
fix z series clean logic (file glob match) add add/port logic for pico series device

### DIFF
--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -516,9 +516,10 @@ def load_active_brew_sessions():
 def load_brew_sessions(uid=None):
     files = []
     if uid:
-        files = list(brew_archive_sessions_path().glob("[^_.]*#{}*.json".format(uid)))
+        files = list(brew_archive_sessions_path().glob("*#{}*.json".format(uid)))
     else:
         files = list(brew_archive_sessions_path().glob(file_glob_pattern))
+
     brew_sessions = [parse_brew_session(file) for file in sorted(files, reverse=True)]
     return list(filter(lambda x: x != None, brew_sessions))
 

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -10,7 +10,7 @@ from . import main
 from .config import MachineType, brew_active_sessions_path, pico_firmware_path
 from .firmware import firmware_filename, minimum_firmware, firmware_upgrade_required
 from .model import PicoBrewSession, PICO_SESSION
-from .routes_frontend import get_pico_recipes
+from .routes_frontend import get_pico_recipes, load_brew_sessions
 from .session_parser import active_brew_sessions
 
 arg_parser = FlaskParser()
@@ -85,7 +85,8 @@ actions_needed_args = {
 @main.route('/API/pico/getActionsNeeded')
 @use_args(actions_needed_args, location='querystring')
 def process_get_actions_needed(args):
-    # TODO : Respond with periodic Deep Clean?
+    if dirty_sessions_since_clean(args['uid']) >= 3:
+        return '#7#'
     return '##'
 
 
@@ -249,6 +250,23 @@ def get_recipe_list():
     for r in get_pico_recipes():
         recipe_list += f'{r.id},{r.name}|'
     return recipe_list
+
+
+def dirty_sessions_since_clean(uid):
+    brew_sessions = load_brew_sessions(uid)
+    post_clean_sessions = []
+    clean_found = False
+    for s in brew_sessions:
+        session_name = s.get('name')
+        
+        if (session_name == "CLEAN"):
+            clean_found = True
+
+
+        if (not clean_found and session_name not in ["RINSE", "CLEAN", "RACK", "DRAIN"]):
+            post_clean_sessions.append(s)
+
+    return len(post_clean_sessions)
 
 
 def create_new_session(uid, sesId, sesType):


### PR DESCRIPTION
The file glob match used to detect sessions of a machine was not matching filenames appropriately anymore.
Ported similar "num_sessions_since_clean" from z into the pico series devices (using comment to decide response format... I don't have a working pico device so can't test).

Tested both z and pico via manually adding files locally and curling the API.

```
curl "localhost/API/pico/getActionsNeeded?uid=pico-needs-cleaning"
#7#%
```

```
curl --location --request PUT 'localhost/Vendors/input.cshtml?type=ZState&token=z-needs-cleaning' \
--header 'Content-Type: application/json' \
--data-raw '{
    "BoilerType": 1,
    "CurrentFirmware": "0.0.119"
}'
{
  "Alias": "ZSeries",
  "BoilerType": 1,
  "IsRegistered": true,
  "IsUpdated": true,
  "ProgramUri": null,
  "RegistrationToken": -1,
  "SessionStats": {
    "DirtySessionsSinceClean": 3,
    "LastSessionType": 0,
    "ResumableSessionID": -1
  },
  "UpdateAddress": "-1",
  "UpdateToFirmware": null,
  "ZBackendError": 0
}
```