### PR TITLE
proper handling of an unknown machine_type for pico firmware

### DIFF
--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -51,9 +51,12 @@ check_firmware_args = {
 @main.route('/API/pico/checkFirmware')
 @use_args(check_firmware_args, location='querystring')
 def process_check_firmware(args):
+    uid = args['uid']
     # only give update available if machine type is known (C firmware != S/Pro Firmware)
-    if args['uid'] in active_brew_sessions and firmware_upgrade_required(active_brew_sessions[args['uid']].machine_type, args['version']):
-        return '#T#'
+    if uid in active_brew_sessions:
+        active_session = active_brew_sessions[uid]
+        if active_session.machine_type and firmware_upgrade_required(active_session.machine_type, args['version']):
+            return '#T#'
     return '#F#'
 
 


### PR DESCRIPTION
Pico C/S/Pro units that didn't have an alias entry in the config would end with a bootloop.

```
Feb 06 09:00:39 raspberrypi rc.local[268]: 127.0.0.1 - - [06/Feb/2021 09:00:39] "GET /API/pico/getFirmware?uid=<uid> HTTP/1.0" 500 -
Feb 06 09:05:58 raspberrypi rc.local[268]: 127.0.0.1 - - [06/Feb/2021 09:05:58] "GET /API/pico/register?uid=<uid> HTTP/1.0" 200 -
Feb 06 09:05:58 raspberrypi rc.local[268]: 127.0.0.1 - - [06/Feb/2021 09:05:58] "GET /API/pico/picoChangeState?picoUID=<uid>&state=2 HTTP/1.0" 200 -
Feb 06 09:06:00 raspberrypi rc.local[268]: [2021-02-06 09:06:00,106] ERROR in app: Exception on /API/pico/checkFirmware [GET]
Feb 06 09:06:00 raspberrypi rc.local[268]: Traceback (most recent call last):
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2447, in wsgi_app
Feb 06 09:06:00 raspberrypi rc.local[268]:     response = self.full_dispatch_request()
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1952, in full_dispatch_request
Feb 06 09:06:00 raspberrypi rc.local[268]:     rv = self.handle_user_exception(e)
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask_cors/extension.py", line 165, in wrapped_function
Feb 06 09:06:00 raspberrypi rc.local[268]:     return cors_after_request(app.make_response(f(*args, **kwargs)))
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1821, in handle_user_exception
Feb 06 09:06:00 raspberrypi rc.local[268]:     reraise(exc_type, exc_value, tb)
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 39, in reraise
Feb 06 09:06:00 raspberrypi rc.local[268]:     raise value
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1950, in full_dispatch_request
Feb 06 09:06:00 raspberrypi rc.local[268]:     rv = self.dispatch_request()
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1936, in dispatch_request
Feb 06 09:06:00 raspberrypi rc.local[268]:     return self.view_functions[rule.endpoint](**req.view_args)
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/usr/local/lib/python3.7/dist-packages/webargs/core.py", line 443, in wrapper
Feb 06 09:06:00 raspberrypi rc.local[268]:     return func(*args, **kwargs)
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/picobrew_pico/app/main/routes_pico_api.py", line 55, in process_check_firmware
Feb 06 09:06:00 raspberrypi rc.local[268]:     if args['uid'] in active_brew_sessions and firmware_upgrade_required(active_brew_sessions[args['uid']].machine_type, args['version']):
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/picobrew_pico/app/main/firmware.py", line 15, in firmware_upgrade_required
Feb 06 09:06:00 raspberrypi rc.local[268]:     return LooseVersion(version) < LooseVersion(minimum_firmware(device))
Feb 06 09:06:00 raspberrypi rc.local[268]:   File "/picobrew_pico/app/main/firmware.py", line 28, in minimum_firmware
Feb 06 09:06:00 raspberrypi rc.local[268]:     raise Exception('invalid device type {}'.format(device))
Feb 06 09:06:00 raspberrypi rc.local[268]: Exception: invalid device type None
Feb 06 09:06:00 raspberrypi rc.local[268]: 127.0.0.1 - - [06/Feb/2021 09:06:00] "GET /API/pico/checkFirmware?uid=<uid>&version=0.1.34 HTTP/1.0" 500 -
```