### PR TITLE
Collapse inactive devices by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ scripts/docker/nginx/certs/*
 # terraform
 terraform/.terraform
 terraform/*.tfstate*
+
+# ignore Visual Studio Code files
+.vscode

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -505,6 +505,7 @@ def load_active_brew_sessions():
     # process brew_sessions from memory
     for uid in active_brew_sessions:
         brew_sessions.append({'alias': active_brew_sessions[uid].alias,
+                              'active': active_brew_sessions[uid].name != 'Waiting To Brew',
                               'machine_type': active_brew_sessions[uid].machine_type,
                               'graph': get_brew_graph_data(uid, active_brew_sessions[uid].name,
                                                            active_brew_sessions[uid].step,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,9 +10,12 @@
   <script>var socket = io.connect('//' + document.domain + ':' + location.port);</script>
   <div id="accordion">
     {% for brew_session in brew_sessions %}
+    {% set chart_id = brew_session.graph.chart_id %}
+    {% set expanded = 'true' if brew_session.active else 'false' %}
+    {% set show = 'show' if brew_session.active else '' %}
     <div class="card bg-dark text-white-50">
-      <h5 class="card-header" id="h_{{brew_session.graph.chart_id}}">
-        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{brew_session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{brew_session.graph.chart_id}}">
+      <h5 class="card-header" id="h_{{chart_id}}">
+        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c_{{chart_id}}">
           <span class="equipment-icon">
             {% if brew_session.machine_type is defined and (brew_session.machine_type == "PicoBrew" or brew_session.machine_type == "PicoBrewC") %}
             <img src="/static/img/picobrew.svg" atl="picobrew c/s/pro" />
@@ -22,12 +25,12 @@
             <img src="/static/img/zseries.svg" atl="zseries" />
             {% endif %}
           </span>
-          {% if brew_session.alias is defined and brew_session.alias|length %}{{brew_session.alias}}{% else %}{{brew_session.graph.chart_id}}{% endif %}
+          {% if brew_session.alias is defined and brew_session.alias|length %}{{brew_session.alias}}{% else %}{{chart_id}}{% endif %}
         </a>
       </h5>
-      <div id="c_{{brew_session.graph.chart_id}}" class="collapse show" aria-labelledby="h_{{brew_session.graph.chart_id}}">
+      <div id="c_{{chart_id}}" class="collapse {{show}}" aria-labelledby="h_{{chart_id}}">
         <div class="card-body">
-          <div id="{{brew_session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
+          <div id="{{chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{brew_session.graph|tojson}};</script>
           <script src="/static/js/brew_graph_socketio.js"></script>
         </div>
@@ -37,37 +40,31 @@
   </div>
   <div id="accordion">
     {% for ferm_session in ferm_sessions %}
+    {% set chart_id = ferm_session.graph.chart_id %}
+    {% set expanded = 'true' if ferm_session.active else 'false' %}
+    {% set show = 'show' if ferm_session.active else '' %}
+    {% set display_start = 'none' if ferm_session.active else 'block' %}
+    {% set display_stop = 'block' if ferm_session.active else 'none' %}
     <div class="card bg-dark text-white-50">
-      <h5 class="card-header" id="h_{{ferm_session.graph.chart_id}}">
-        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{ferm_session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{ferm_session.graph.chart_id}}">
+      <h5 class="card-header" id="h_{{chart_id}}">
+        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c_{{chart_id}}">
           <span class="equipment-icon">
             <img src="/static/img/picoferm.svg" atl="picoferm">
           </span>
-          {% if ferm_session.alias is defined and ferm_session.alias|length %}{{ferm_session.alias}}{% else %}{{ferm_session.graph.chart_id}}{% endif %}
-          {% if ferm_session.active %}
-          <button class="fermentation-start d-none btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
+          {% if ferm_session.alias is defined and ferm_session.alias|length %}{{ferm_session.alias}}{% else %}{{chart_id}}{% endif %}
+          <button class="fermentation-start d-{{display_start}} btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();start_fermentation('{{ferm_session.uid}}');">
               <i class="fas fa-play-circle"></i> Start Fermentation
           </button>
-          <button class="fermentation-stop d-block btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
+          <button class="fermentation-stop d-{{display_stop}} btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();stop_fermentation('{{ferm_session.uid}}');">
               <i class="fas fa-stop-circle"></i> Stop Fermentation
           </button>
-          {% else %}
-          <button class="fermentation-start d-block btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
-              onclick="event.stopPropagation();event.preventDefault();start_fermentation('{{ferm_session.uid}}');">
-              <i class="fas fa-play-circle"></i> Start Fermentation
-          </button>
-          <button class="fermentation-stop d-none btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
-              onclick="event.stopPropagation();event.preventDefault();stop_fermentation('{{ferm_session.uid}}');">
-              <i class="fas fa-stop-circle"></i> Stop Fermentation
-          </button>
-          {% endif %}
         </a>
       </h5>
-      <div id="c_{{ferm_session.graph.chart_id}}" class="collapse show" aria-labelledby="h_{{ferm_session.graph.chart_id}}">
+      <div id="c_{{chart_id}}" class="collapse {{show}}" aria-labelledby="h_{{chart_id}}">
         <div class="card-body">
-          <div id="{{ferm_session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
+          <div id="{{chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{ferm_session.graph|tojson}};</script>
           <script src="/static/js/ferm_graph_socketio.js"></script>
         </div>
@@ -77,37 +74,31 @@
   </div>
   <div id="accordion">
     {% for iSpindel_session in iSpindel_sessions %}
+    {% set chart_id = iSpindel_session.graph.chart_id %}
+    {% set expanded = 'true' if iSpindel_session.active else 'false' %}
+    {% set show = 'show' if iSpindel_session.active else '' %}
+    {% set display_start = 'none' if iSpindel_session.active else 'block' %}
+    {% set display_stop = 'block' if iSpindel_session.active else 'none' %}
     <div class="card bg-dark text-white-50">
-      <h5 class="card-header" id="h_{{iSpindel_session.graph.chart_id}}">
-        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{iSpindel_session.graph.chart_id}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{iSpindel_session.graph.chart_id}}">
+      <h5 class="card-header" id="h_{{chart_id}}">
+        <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c_{{chart_id}}">
           <span class="equipment-icon">
             <img src="/static/img/tilt.svg" atl="tilt or ispindle">
           </span>
-          {% if iSpindel_session.alias is defined and iSpindel_session.alias|length %}{{iSpindel_session.alias}}{% else %}{{iSpindel_session.graph.chart_id}}{% endif %}
-          {% if iSpindel_session.active %}
-          <button class="fermentation-start d-none btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{iSpindel_session.uid}}"
+          {% if iSpindel_session.alias is defined and iSpindel_session.alias|length %}{{iSpindel_session.alias}}{% else %}{{chart_id}}{% endif %}
+          <button class="fermentation-{{display_start}} d-none btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{iSpindel_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();start_iSpindel_fermentation('{{iSpindel_session.uid}}');">
               <i class="fas fa-play-circle"></i> Start Fermentation
           </button>
-          <button class="fermentation-stop d-block btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{iSpindel_session.uid}}"
+          <button class="fermentation-{{display_stop}} d-block btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{iSpindel_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();stop_iSpindel_fermentation('{{iSpindel_session.uid}}');">
               <i class="fas fa-stop-circle"></i> Stop Fermentation
           </button>
-          {% else %}
-          <button class="fermentation-start d-block btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{iSpindel_session.uid}}"
-              onclick="event.stopPropagation();event.preventDefault();start_iSpindel_fermentation('{{iSpindel_session.uid}}');">
-              <i class="fas fa-play-circle"></i> Start Fermentation
-          </button>
-          <button class="fermentation-stop d-none btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{iSpindel_session.uid}}"
-              onclick="event.stopPropagation();event.preventDefault();stop_iSpindel_fermentation('{{iSpindel_session.uid}}');">
-              <i class="fas fa-stop-circle"></i> Stop Fermentation
-          </button>
-          {% endif %}
         </a>
       </h5>
-      <div id="c_{{iSpindel_session.graph.chart_id}}" class="collapse show" aria-labelledby="h_{{iSpindel_session.graph.chart_id}}">
+      <div id="c_{{chart_id}}" class="collapse {{show}}" aria-labelledby="h_{{chart_id}}">
         <div class="card-body">
-          <div id="{{iSpindel_session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
+          <div id="{{chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{iSpindel_session.graph|tojson}};</script>
           <script src="/static/js/iSpindel_graph_socketio.js"></script>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,8 +43,8 @@
     {% set chart_id = ferm_session.graph.chart_id %}
     {% set expanded = 'true' if ferm_session.active else 'false' %}
     {% set show = 'show' if ferm_session.active else '' %}
-    {% set display_start = 'none' if ferm_session.active else 'block' %}
-    {% set display_stop = 'block' if ferm_session.active else 'none' %}
+    {% set display_start = 'd-none' if ferm_session.active else 'd-block' %}
+    {% set display_stop = 'd-block' if ferm_session.active else 'd-none' %}
     <div class="card bg-dark text-white-50">
       <h5 class="card-header" id="h_{{chart_id}}">
         <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c_{{chart_id}}">
@@ -52,11 +52,11 @@
             <img src="/static/img/picoferm.svg" atl="picoferm">
           </span>
           {% if ferm_session.alias is defined and ferm_session.alias|length %}{{ferm_session.alias}}{% else %}{{chart_id}}{% endif %}
-          <button class="fermentation-start d-{{display_start}} btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
+          <button class="fermentation-start {{display_start}} btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{ferm_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();start_fermentation('{{ferm_session.uid}}');">
               <i class="fas fa-play-circle"></i> Start Fermentation
           </button>
-          <button class="fermentation-stop d-{{display_stop}} btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
+          <button class="fermentation-stop {{display_stop}} btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{ferm_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();stop_fermentation('{{ferm_session.uid}}');">
               <i class="fas fa-stop-circle"></i> Stop Fermentation
           </button>
@@ -77,8 +77,8 @@
     {% set chart_id = iSpindel_session.graph.chart_id %}
     {% set expanded = 'true' if iSpindel_session.active else 'false' %}
     {% set show = 'show' if iSpindel_session.active else '' %}
-    {% set display_start = 'none' if iSpindel_session.active else 'block' %}
-    {% set display_stop = 'block' if iSpindel_session.active else 'none' %}
+    {% set display_start = 'd-none' if iSpindel_session.active else 'd-block' %}
+    {% set display_stop = 'd-block' if iSpindel_session.active else 'd-none' %}
     <div class="card bg-dark text-white-50">
       <h5 class="card-header" id="h_{{chart_id}}">
         <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c_{{chart_id}}">
@@ -86,11 +86,11 @@
             <img src="/static/img/tilt.svg" atl="tilt or ispindle">
           </span>
           {% if iSpindel_session.alias is defined and iSpindel_session.alias|length %}{{iSpindel_session.alias}}{% else %}{{chart_id}}{% endif %}
-          <button class="fermentation-{{display_start}} d-none btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{iSpindel_session.uid}}"
+          <button class="fermentation-start {{display_start}} btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{iSpindel_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();start_iSpindel_fermentation('{{iSpindel_session.uid}}');">
               <i class="fas fa-play-circle"></i> Start Fermentation
           </button>
-          <button class="fermentation-{{display_stop}} d-block btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{iSpindel_session.uid}}"
+          <button class="fermentation-stop {{display_stop}} btn btn-sm btn-danger float-right mr-5" type="button" id="bstop_{{iSpindel_session.uid}}"
               onclick="event.stopPropagation();event.preventDefault();stop_iSpindel_fermentation('{{iSpindel_session.uid}}');">
               <i class="fas fa-stop-circle"></i> Stop Fermentation
           </button>


### PR DESCRIPTION
and some refactoring to lessen duplicate markup and improve readability.

Before the devices were all expanded when you load the page, which makes you scroll to get to the info you want - like if you are fermenting, and not brewing.

This merge request collapses inactive devices so the active ones are more prominent.