### PR TITLE
Update Brew Session Graphing (error/pause states)

### DIFF
--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -467,13 +467,15 @@ def update_session_log(token, body):
     active_session.remaining_time = body['SecondsRemaining']
 
     plot_bands = active_session.plot_band or []
-    if session_data.get('pauseReason') != 0 or session_data.get('errorCode') != 0:
+    error_code = session_data.get('pauseReason', 0)
+    pause_reason = session_data.get('errorCode', 0)
+    if pause_reason != 0 or error_code != 0:
         if len(plot_bands) == 0:
             plot_bands.append({
                 'from': session_data.get('time'),
                 'to': None,
                 'label': {
-                    'text': reason_phrase(session_data.get('errorCode', 0), session_data.get('pauseReason', 0))
+                    'text': reason_phrase(error_code, pause_reason)
                 }
             })
             session_data.update({'plot_bands': plot_bands})

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -447,7 +447,7 @@ def update_session_log(token, body):
         'drainPumpOn': body.get('DrainPumpOn', 0) == 1, # integer into boolean
         'kegPumpOn': body.get('KegPumpOn', 0) == 1,     # integer into boolean
         'errorCode': body.get('ErrorCode'),             # integer (4 == Overheat - too hot; 6 == Overheat - Max HEX Wort Delta; 12 == PicoStill Error)
-        'pauseReason': body.get('PauseReason'),         # integer (1 == waiting for user / finished / program)
+        'pauseReason': body.get('PauseReason'),         # integer (1 == waiting for user / finished / program, 2 == user initiated, 0 == running / not pause)
         # debug wifi information
         'network': {
             'recv': body.get('netRecv'),
@@ -487,6 +487,9 @@ def update_session_log(token, body):
             })
         elif len(session_plot_bands) > 0:
             session_plot_bands[-1]['to'] = session_data.get('time')
+
+    elif session_plot_bands[-1]['to'] == None:
+        session_plot_bands[-1]['to'] = active_session.data[-1].get('time')
 
     # for Z graphs we have more data available: wort, hex/therm, target, drain, ambient
     graph_update = json.dumps({'time': session_data['time'],

--- a/app/main/routes_zseries_api.py
+++ b/app/main/routes_zseries_api.py
@@ -466,7 +466,10 @@ def update_session_log(token, body):
     active_session.recovery = body['StepName']
     active_session.remaining_time = body['SecondsRemaining']
 
-    plot_bands = active_session.plot_band or []
+    plot_bands = []
+    if plot_band in active_session:
+        plot_bands = active_session.plot_band
+
     error_code = session_data.get('pauseReason', 0)
     pause_reason = session_data.get('errorCode', 0)
     if pause_reason != 0 or error_code != 0:

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -155,7 +155,7 @@ def get_brew_graph_data(chart_id, session_name, session_step, session_data, is_p
         # add an overlay error for each errorCode or pauseReason
         error_code = data['errorCode'] if 'errorCode' in data else 0
         pause_reason = data['pauseReason'] if 'pauseReason' in data else 0
-        if error_code > 0 or pause_reason > 0:
+        if error_code != 0 or pause_reason != 0:
             if len(plot_bands) == 0:
                 plot_bands.append({
                     'from': data.get('time'),

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -164,8 +164,8 @@ def get_brew_graph_data(chart_id, session_name, session_step, session_data, is_p
                         'text': reason_phrase(error_code, pause_reason)
                     }
                 })
-        elif len(plot_bands) > 0:
-            plot_bands[-1].update({'to', data.get('time')})
+            elif len(plot_bands) > 0:
+                plot_bands[-1]['to'] = data.get('time')
 
     # if last data point is pause or error
     if len(plot_bands) > 0 and plot_bands[-1]['to'] == None:

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -265,7 +265,7 @@ def reason_phrase(error_code, pause_reason):
         if pause_reason == 2:
             reason += 'user'
     elif error_code != 0:
-        reason += 'error: {error_code}'
+        reason += f'error: {error_code}'
 
     return reason
 
@@ -505,7 +505,6 @@ def restore_active_brew_sessions():
             session.file.flush()
             session.filepath = file
             session.created_at = brew_session['date']
-            current_app.logger.debug(f'current created_at : {session.created_at}')
             session.name = brew_session['name']
             session.type = brew_session['type']
             session.session = brew_session['session']                   # session guid

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -237,6 +237,14 @@ def load_ferm_session(file):
 
 
 # map programmatic codes to user facing strings (displayed in the brew graph)
+#
+# error codes:
+#   4 == Overheat - too hot
+#   6 == Overheat - Max HEX Wort Delta
+#  12 == PicoStill Error
+#
+# pause reasons:
+#   1 == waiting for user / finished / program
 def reason_phrase(error_code, pause_reason):
     reason = ''
     if pause_reason != 0:

--- a/app/static/js/brew_graph.js
+++ b/app/static/js/brew_graph.js
@@ -30,8 +30,14 @@ Highcharts.chart(graph_data.chart_id, {
 
   tooltip: {
     formatter: function() {
+        const chart = this.points[0].series.chart;
+
         var s = '<b>'+ Highcharts.dateFormat('%A, %b %e %k:%M:%S.%L', // Friday, Jan ## ##:##:##.####
           new Date(this.x)) +'</b>';
+
+        if (chart.pauseReason) {
+            s += `<br/><span style="color:red; font-size: 18px;">${chart.pauseReason.toUpperCase()}</span>`
+        }
 
         $.each(this.points, function(i, point) {
             s += '<br/><span style="color:' + point.color + '">\u25CF</span> ' + point.series.name + ': ' + point.y;
@@ -47,7 +53,33 @@ Highcharts.chart(graph_data.chart_id, {
     title: {
       text: 'Time'
     },
-    plotLines: graph_data.xaplotlines
+    plotLines: graph_data.xaplotlines.map(plotLine => {
+      plotLine.width = 2;
+      plotLine.label.style = {'color': 'white', 'fontWeight': 'bold'};
+      plotLine.label.verticalAlign = 'top';
+      plotLine.label.x = -15;
+      plotLine.label.y = 0;
+      return plotLine;
+    }),
+    plotBands: graph_data.xaplotbands.map(plotBand => {
+      plotBand.color = 'rgba(255, 86, 48, .2)';
+      if (plotBand.label.text.includes('pause')) {
+        plotBand.label.style = {'color': 'yellow', 'fontWeight': 'bold'};
+      } else {
+        plotBand.label.style = {'color': 'red', 'fontWeight': 'bold'};
+      }
+      plotBand.events = {
+        mouseover: function(e) {
+          const chart = this.axis.chart;
+          chart.pauseReason = this.options.label.text
+        },
+        mouseout: function(e) {
+          const chart = this.axis.chart;
+          chart.pauseReason = this.options.label.text
+        }
+      };
+      return plotBand
+    })
   },
 
   yAxis: {

--- a/app/static/js/brew_graph.js
+++ b/app/static/js/brew_graph.js
@@ -71,14 +71,14 @@ Highcharts.chart(graph_data.chart_id, {
       plotBand.events = {
         mouseover: function(e) {
           const chart = this.axis.chart;
-          chart.pauseReason = this.options.label.text
+          chart.pauseReason = this.options.label.text;
         },
         mouseout: function(e) {
           const chart = this.axis.chart;
-          chart.pauseReason = this.options.label.text
+          chart.pauseReason = null;
         }
       };
-      return plotBand
+      return plotBand;
     })
   },
 

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -21,6 +21,12 @@ Highcharts.chart(graph_data.chart_id, {
             {
               self.xAxis[0].addPlotLine({ 'color': 'black', 'width': '2', 'value': data.time, 'label': {'text': data.event, 'style': {'color': 'white', 'fontWeight': 'bold'}, 'verticalAlign': 'top', 'x': -15, 'y': 0}});
             }
+
+            if ('to' in data.plotBand && data.plotBand.to == null)
+            {
+              self.xAxis[0].options.plotBands[-1] = data.plotBand;
+              self.xAxis[0].update();
+            }
         });
       },
     },
@@ -90,14 +96,14 @@ Highcharts.chart(graph_data.chart_id, {
       plotBand.events = {
         mouseover: function(e) {
           const chart = this.axis.chart;
-          chart.pauseReason = this.options.label.text
+          chart.pauseReason = this.options.label.text;
         },
         mouseout: function(e) {
           const chart = this.axis.chart;
-          chart.pauseReason = this.options.label.text
+          chart.pauseReason = null;
         }
       };
-      return plotBand
+      return plotBand;
     })
   },
 

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -49,14 +49,20 @@ Highcharts.chart(graph_data.chart_id, {
 
   tooltip: {
     formatter: function() {
-        var s = '<b>'+ Highcharts.dateFormat('%A, %b %e %k:%M:%S.%L', // Friday, Jan ## ##:##:##.####
-          new Date(this.x)) +'</b>';
+      const chart = this.points[0].series.chart;
 
-        $.each(this.points, function(i, point) {
-            s += '<br/><span style="color:' + point.color + '">\u25CF</span> ' + point.series.name + ': ' + point.y;
-        });
+      var s = '<b>'+ Highcharts.dateFormat('%A, %b %e %k:%M:%S.%L', // Friday, Jan ## ##:##:##.####
+        new Date(this.x)) +'</b>';
 
-        return s;
+      if (chart.pauseReason) {
+          s += `<br/><span style="color:red; font-size: 18px;">${chart.pauseReason.toUpperCase()}</span>`
+      }
+
+      $.each(this.points, function(i, point) {
+          s += '<br/><span style="color:' + point.color + '">\u25CF</span> ' + point.series.name + ': ' + point.y;
+      });
+
+      return s;
     },
     shared: true
   },
@@ -66,7 +72,33 @@ Highcharts.chart(graph_data.chart_id, {
     title: {
       text: 'Time'
     },
-    plotLines: graph_data.xaplotlines
+    plotLines: graph_data.xaplotlines.map(plotLine => {
+      plotLine.width = 2;
+      plotLine.label.style = {'color': 'white', 'fontWeight': 'bold'};
+      plotLine.label.verticalAlign = 'top';
+      plotLine.label.x = -15;
+      plotLine.label.y = 0;
+      return plotLine;
+    }),
+    plotBands: graph_data.xaplotbands.map(plotBand => {
+      plotBand.color = 'rgba(255, 86, 48, .2)';
+      if (plotBand.label.text.includes('pause')) {
+        plotBand.label.style = {'color': 'yellow', 'fontWeight': 'bold'};
+      } else {
+        plotBand.label.style = {'color': 'red', 'fontWeight': 'bold'};
+      }
+      plotBand.events = {
+        mouseover: function(e) {
+          const chart = this.axis.chart;
+          chart.pauseReason = this.options.label.text
+        },
+        mouseout: function(e) {
+          const chart = this.axis.chart;
+          chart.pauseReason = this.options.label.text
+        }
+      };
+      return plotBand
+    })
   },
 
   yAxis: {

--- a/app/static/js/brew_graph_socketio.js
+++ b/app/static/js/brew_graph_socketio.js
@@ -14,18 +14,43 @@ Highcharts.chart(graph_data.chart_id, {
         {
             var data = JSON.parse(event);
             self.setTitle({text: data.session}, {text: data.step});
+
             for (var i = 0; i < data.data.length; i++){
               self.series[i].addPoint([data.time, data.data[i]]);
             }
+
             if (data.event)
             {
               self.xAxis[0].addPlotLine({ 'color': 'black', 'width': '2', 'value': data.time, 'label': {'text': data.event, 'style': {'color': 'white', 'fontWeight': 'bold'}, 'verticalAlign': 'top', 'x': -15, 'y': 0}});
             }
 
-            if ('to' in data.plotBand && data.plotBand.to == null)
+            if ('plotBand' in data && data.plotBand && !$.isEmptyObject(data.plotBand))
             {
-              self.xAxis[0].options.plotBands[-1] = data.plotBand;
-              self.xAxis[0].update();
+              if (self.xAxis[0].options.plotBands.length > 0 && data.plotBand.from == self.xAxis[0].options.plotBands.at(-1).from)
+              {
+                // self.xAxis[0].options.plotBands.push(data.plotBand);
+                self.xAxis[0].options.plotBands.at(-1).to = data.time
+                self.xAxis[0].update();
+              } else {
+                data.plotBand.color = 'rgba(255, 86, 48, .2)';
+                if (data.plotBand.label.text.includes('pause')) {
+                  data.plotBand.label.style = {'color': 'yellow', 'fontWeight': 'bold'};
+                } else {
+                  data.plotBand.label.style = {'color': 'red', 'fontWeight': 'bold'};
+                }
+                data.plotBand.events = {
+                  mouseover: function(e) {
+                    const chart = this.axis.chart;
+                    chart.pauseReason = this.options.label.text;
+                  },
+                  mouseout: function(e) {
+                    const chart = this.axis.chart;
+                    chart.pauseReason = null;
+                  }
+                };
+                self.xAxis[0].options.plotBands.push(data.plotBand);
+                self.xAxis[0].update();
+              }
             }
         });
       },


### PR DESCRIPTION
- include additional data submitted from ZSeries devices into the brew session file
- visually display pause/error state as plotBand
- refactor chart styling in javascript vs in python code (need to port to pico and ferm devices)
- include plotBand label.text into the chart tooltip.formatter

I've tested this with manually created files generated from a prior brew session, I don't know how to trigger all the different error conditions on the device but I'm certain that the device only sends `int` types for `PauseReason` and `ErrorCode` so tracking those as `int` for now. While only "translating" the ones that we know about as we detect them... Right now the main one is `PauseReason: 1` which is when you program a pause (or the recipe ends). I'm not positive that the error codes listed on the support site match 1-1 for the error codes in the API.

![image](https://user-images.githubusercontent.com/2158627/107597874-ffe9da80-6be9-11eb-8a56-a84930f34545.png)

![image](https://user-images.githubusercontent.com/2158627/107598410-9bc81600-6beb-11eb-8182-f4d2cb48cdef.png)
