### PR TITLE
Display no devices configured

### DIFF
--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -45,18 +45,6 @@ def handle_devices():
             return render_template_with_defaults('devices.html', error=error,
                 config=server_config(), active_sessions=active_sessions)
 
-        # uid and alias are required
-        if len(uid) == 0 or len(alias) == 0:
-            if len(uid) == 0 and len(alias) == 0:
-                error = f'Machine/Product ID and Alias are required'
-            elif len(uid) == 0:
-                error = f'Machine/Product ID is required'
-            else:
-                error = f'Alias is required'
-            current_app.logger.error(error)
-            return render_template_with_defaults('devices.html', error=error,
-                config=server_config(), active_sessions=active_sessions)
-
         # verify uid not already configured
         if (uid in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_still_sessions} 
                 and active_session(uid).alias != ''):

--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -45,15 +45,14 @@ def handle_devices():
             return render_template_with_defaults('devices.html', error=error,
                 config=server_config(), active_sessions=active_sessions)
 
-        # uid iand alias are required
+        # uid and alias are required
         if len(uid) == 0 or len(alias) == 0:
-            error = ''
-            if len(uid) == 0:
+            if len(uid) == 0 and len(alias) == 0:
+                error = f'Machine/Product ID and Alias are required'
+            elif len(uid) == 0:
                 error = f'Machine/Product ID is required'
-            if len(alias) == 0:
-                if len(uid) == 0:
-                    error += f' and '
-                error += f'Alias is required'
+            else:
+                error = f'Alias is required'
             current_app.logger.error(error)
             return render_template_with_defaults('devices.html', error=error,
                 config=server_config(), active_sessions=active_sessions)

--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -45,6 +45,19 @@ def handle_devices():
             return render_template_with_defaults('devices.html', error=error,
                 config=server_config(), active_sessions=active_sessions)
 
+        # uid iand alias are required
+        if len(uid) == 0 or len(alias) == 0:
+            error = ''
+            if len(uid) == 0:
+                error = f'Machine/Product ID is required'
+            if len(alias) == 0:
+                if len(uid) == 0:
+                    error += f' and '
+                error += f'Alias is required'
+            current_app.logger.error(error)
+            return render_template_with_defaults('devices.html', error=error,
+                config=server_config(), active_sessions=active_sessions)
+
         # verify uid not already configured
         if (uid in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_still_sessions} 
                 and active_session(uid).alias != ''):

--- a/app/templates/devices.html
+++ b/app/templates/devices.html
@@ -54,7 +54,7 @@
       {% else %}
       <h2 id="m_{{machine_type}}">{{machine_type}}</h2>
       {% endif %}
-      {% if config['aliases'][machine_type] == None %}
+      {% if config['aliases'][machine_type] == None or not config['aliases'][machine_type] %}
       <p>No devices configurated</p>
       {% else %}
       {% for uid in config['aliases'][machine_type] %}

--- a/app/templates/devices.html
+++ b/app/templates/devices.html
@@ -55,7 +55,7 @@
       <h2 id="m_{{machine_type}}">{{machine_type}}</h2>
       {% endif %}
       {% if config['aliases'][machine_type] == None or not config['aliases'][machine_type] %}
-      <p>No devices configurated</p>
+      <p>No devices configured</p>
       {% else %}
       {% for uid in config['aliases'][machine_type] %}
       <div class="card bg-dark text-white-50">


### PR DESCRIPTION
After adding and then deleting devices, the yaml generated leaves an empty dict and the "No devices configured" message no longer displays.
