### PR TITLE
Include Calculated End Date in History

### DIFF
--- a/app/templates/brew_history.html
+++ b/app/templates/brew_history.html
@@ -38,7 +38,7 @@
               </div>
               <div class="col-sm">
                 <div class="text-white-50">Date Completed</div>
-                <div>Unknown</div>
+                <div>{{session.end_date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
               </div>
             </div>
             <div class="row">&nbsp;</div>

--- a/app/templates/ferm_history.html
+++ b/app/templates/ferm_history.html
@@ -26,6 +26,23 @@
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">
         <div class="card-body">
+          <div id="d_{{session.graph.chart_id}}" class="text-white">
+            <div class="row">
+              <div class="col-sm">
+                <div class="text-white-50">Device</div>
+                <div>{% if session.alias is defined and session.alias|length %}{{session.alias}} ({{session.uid}}){% else %}{{session.uid}}{% endif %}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Started</div>
+                <div>{{session.date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Completed</div>
+                <div>{{session.end_date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
+              </div>
+            </div>
+            <div class="row">&nbsp;</div>
+          </div>
           <div id="{{session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{session.graph|tojson}};</script>
           <script src="/static/js/ferm_graph.js"></script>

--- a/app/templates/iSpindel_history.html
+++ b/app/templates/iSpindel_history.html
@@ -26,6 +26,23 @@
       </h5>
       <div id="c_{{session.graph.chart_id}}" class="collapse" aria-labelledby="h_{{session.graph.chart_id}}">
         <div class="card-body">
+          <div id="d_{{session.graph.chart_id}}" class="text-white">
+            <div class="row">
+              <div class="col-sm">
+                <div class="text-white-50">Device</div>
+                <div>{% if session.alias is defined and session.alias|length %}{{session.alias}} ({{session.uid}}){% else %}{{session.uid}}{% endif %}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Started</div>
+                <div>{{session.date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
+              </div>
+              <div class="col-sm">
+                <div class="text-white-50">Date Completed</div>
+                <div>{{session.end_date.strftime('%A, %b %e %Y %H:%M:%S')}}</div>
+              </div>
+            </div>
+            <div class="row">&nbsp;</div>
+          </div>
           <div id="{{session.graph.chart_id}}" style="min-width: 320px; height: 400px; margin: 0 auto"></div>
           <script>var graph_data={{session.graph|tojson}};</script>
           <script src="/static/js/iSpindel_graph.js"></script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask==1.1.2
 ruamel.yaml==0.16.12
 requests==2.25.0
 mock==4.0.3
+python-dateutil==2.8.1


### PR DESCRIPTION
- calculate from data log the end date of sessions
- port machine/device, start date, end date view for ferm and ispindel devices
- fix timezone for start date and end date to be server timezone using dateutils helpers

Brew Session
![image](https://user-images.githubusercontent.com/2158627/108599636-57ade180-7360-11eb-8242-c86037e44069.png)

Ferm Session
![image](https://user-images.githubusercontent.com/2158627/108599643-66949400-7360-11eb-8b87-d9a4ab5c195c.png)

iSpindel Session
![image](https://user-images.githubusercontent.com/2158627/108599675-85932600-7360-11eb-8ff1-aca4b60ab3a1.png)
