### PR TITLE
[nginx config] ignore client timeouts, disable socket.io access logs and setup nginx config for easy updating

### DIFF
--- a/scripts/pi/picobrew.com.conf
+++ b/scripts/pi/picobrew.com.conf
@@ -16,6 +16,7 @@ server {
         aio threads;
 
         # socket.io logs are annoying, noisy and mostly useless
+        error_log off;
         access_log off;
         
         include proxy_params;
@@ -53,6 +54,7 @@ server {
         aio threads;
 
         # socket.io logs are annoying, noisy and mostly useless
+        error_log off;
         access_log off;
         
         include proxy_params;

--- a/scripts/pi/picobrew.com.conf
+++ b/scripts/pi/picobrew.com.conf
@@ -1,0 +1,65 @@
+server {
+    listen 80;
+    server_name www.picobrew.com picobrew.com;
+
+    access_log                  /var/log/nginx/picobrew.access.log;
+    error_log                   /var/log/nginx/picobrew.error.log;
+    
+    location / {
+        aio threads;
+
+        proxy_set_header    Host $http_host;
+        proxy_pass          http://127.0.0.1:8080;
+    }
+
+    location /socket.io {
+        aio threads;
+
+        # socket.io logs are annoying, noisy and mostly useless
+        access_log off;
+        
+        include proxy_params;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass http://127.0.0.1:8080/socket.io;
+        proxy_ignore_client_abort on;  # ignore client timeouts resulting in 499 error responses
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name www.picobrew.com picobrew.com;
+
+    ssl_certificate             /certs/bundle.crt;
+    ssl_certificate_key         /certs/server.key;
+    
+    access_log                  /var/log/nginx/picobrew.access.log;
+    error_log                   /var/log/nginx/picobrew.error.log;
+    
+    location / {
+        aio threads;
+
+        proxy_set_header    Host $http_host;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_pass          http://127.0.0.1:8080;
+        proxy_ignore_client_abort on;  # ignore client timeouts resulting in 499 error responses
+    }
+    
+    location /socket.io {
+        aio threads;
+
+        # socket.io logs are annoying, noisy and mostly useless
+        access_log off;
+        
+        include proxy_params;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass http://127.0.0.1:8080/socket.io;
+    }
+}


### PR DESCRIPTION
1) ignore client timeouts (seems that picobrew firmware doesn't wait for a response and is a fire and forget for data logs)
2) disable all error and access logging for /socket.io requests... these are annoying me so much
3) symlink the nginx config for picobrew_pico from the application installation folder (`/picobrew_pico/scripts/pi`) instead so `git pull` can update the nginx configuration (this paired with @cgalpin's ideas around running a script post git pull, https://github.com/chiefwigms/picobrew_pico/pull/266, can restart nginx if needed based on file modification date)