### PR TITLE
Added hook/script to run after git updates

### DIFF
--- a/app/main/routes_server.py
+++ b/app/main/routes_server.py
@@ -25,6 +25,10 @@ def restart_server():
     os.system('cd {0}; git pull; pip3 install -r requirements.txt'.format(base_path()))
     # TODO: Close file handles for open sessions?
 
+    if platform() == "RaspberryPi":
+        update_script="./scripts/pi/post-git-update.sh"
+        os.system('cd {0}; if [ -f {1} ]; then {1} --allow-reboot; fi'.format(base_path(), update_script))
+
     def restart():
         sleep(2)
         os.execl(sys.executable, *([sys.executable]+sys.argv))

--- a/scripts/pi/00-run-chroot.sh
+++ b/scripts/pi/00-run-chroot.sh
@@ -309,6 +309,7 @@ then
   git pull || true
   # install dependencies and start server
   pip3 install -r requirements.txt
+  ./scripts/pi/post-git-update.sh
 fi
 
 source_sha=${GIT_SHA}

--- a/scripts/pi/post-git-update.sh
+++ b/scripts/pi/post-git-update.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# hook to allow additional steps during an update. This gets called after
+# a "git pull; pip3 install -r requirements.txt"
+# and expects to have passwordless sudo
+
+# figure out the absolute path to the root of the server install
+script_dir=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
+root_dir=${script_dir%/scripts/pi}
+echo Using server root of $root_dir
+
+allow_reboot=0
+if [ "$1" == "--allow-reboot" ]; then
+    allow_reboot=1
+fi
+
+# sanity check we are using the right root install
+if [ ! -f $root_dir/config.yaml ]; then
+    echo Unable to find $root_dir/config.yaml. Aborting...
+    exit 1
+fi
+
+# older installs may not have had bluetooth support enabled/configured
+# so add configuration and enable by default
+if grep -q ^tilt_monitoring $root_dir/config.yaml; then
+    echo Bluetooth already configured in config.yaml
+else
+    echo Adding bluetooth configuration \(enabled\) to config.yaml
+
+    cat >> $root_dir/config.yaml <<EOF
+
+# Enable Tilt support (bluetooth). Set to False to disable
+tilt_monitoring: True
+# the interval in seconds before checking for tilt data
+tilt_monitoring_interval: 10
+EOF
+fi
+
+# Raspberry Pi specific stuff here
+if [ -f /proc/device-tree/model ] && grep -iq raspberry /proc/device-tree/model; then
+    echo -n "Running on "; cat /proc/device-tree/model; echo
+
+    # older raspberry-pi images had bluetooth disabled
+    # so re-enable on those. This requires a reboot
+    if grep -q "^dtoverlay\s*=\s*disable-bt" /boot/config.txt; then
+        # allow a way for someone to intentionally disable bluetooth if so desired
+        if grep -q picobrew_pico:intentionally-disable-bluetooth /boot/config.txt; then
+            echo Bluetooth intentionally disabled. Leaving disabled...
+        else
+            echo Restoring OS bluetooth support in /boot/config.txt
+            sudo sed -i "s/^dtoverlay\s*=\s*disable-bt/#&/" /boot/config.txt
+
+            echo Making bluetooth accessible without being root...
+            sudo setcap cap_net_raw+eip /usr/bin/python3.7
+            sudo usermod -a -G bluetooth pi
+            sudo systemctl restart dbus
+
+            # best do this now to avoid any confusion
+            if [ $allow_reboot -eq 1 ]; then
+                echo Rebooting to enable changes. Will be right back...
+                sudo shutdown -r now
+            else
+                echo A reboot will be required to enable bluetooth
+            fi
+        fi
+    else
+        echo Bluetooth already enabled at OS level
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
Take 2

This will cover the current need to update existing installations with bluetooth disabled, and a place to add additional checks in the future.

It will run on reboot if/when update_boot is true, as well as when the server is updated via the UI when on a raspberry pi.