### PR TITLE
remove auto start poll for picostill (ip address isn't known)

### DIFF
--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -482,8 +482,7 @@ def restore_active_still_sessions():
             session.filepath = file
             session.alias = still_session['alias']
             session.start_time = still_session['date']
-            session.active = True
-            session.start_still_polling()
+            session.active = False
 
             session.data = still_session['data']
             session.graph = still_session['graph']


### PR DESCRIPTION
to properly auto start a poll for picostill data we need to know the ip address... unfortunately the setup right now doesn't have a way to distribute that across a raspberrypi restart and likely the dhcp lease might change anyways since the dhcp server could also have restarted.

for now I'm just removing this