### PR TITLE
remove special characters in the tilt address break due to html anchor incompatibility

### DIFF
--- a/app/main/tilt.py
+++ b/app/main/tilt.py
@@ -58,7 +58,7 @@ def tilts(devices):
                     # but add uid and rssi
                     color = TILTS[color_uid]
                     tilts.append({
-                        'uid': color + '-' + d.address,
+                        'uid': color + '-' + d.address.replace(":", "").replace("-", ""),  # remove special characters from the device address
                         'rssi': get_rssi(data[22:23]),
                         'color': color,
                         'timestamp': datetime.utcnow().isoformat(),


### PR DESCRIPTION
These special characters ':' in the href / id fields in HTML break the expand functionality of the accordians in bootstrap. So I've decided to remove both the ':' (linux/win address) and '-' (macos address). These also just caused the device name to be longer which just looked weird in narrow displays (phones).

cc/ @cgalpin have a look, though fairly simple