### PR TITLE
correct the valid Celsius range for tooltip

### DIFF
--- a/app/static/js/base_recipe.js
+++ b/app/static/js/base_recipe.js
@@ -23,7 +23,7 @@ function recipe_tooltips(machine_type) {
                 if (selected_units == 'imperial') {
                     tip += `[0 - 208] (°F)`;
                 } else {
-                    tip += `[${convert_temperature(0, selected_units)} - ${convert_temperature(100, selected_units)}] (°C)`;
+                    tip += `[${convert_temperature(0, selected_units)} - ${convert_temperature(208, selected_units)}] (°C)`;
                 }
                 break;
             case "step_time":


### PR DESCRIPTION
@LEFsher I'm not sure how you are getting a row that is invalid as this code for the tooltip doesn't validate the row entry that happens else where and at least on my dev machine is working as expected in both F and C modes.