### PR TITLE
wrap tilt imports (which include bluetooth) in a try/except

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PORT=80
 
 WORKDIR /picobrew_pico
 
+RUN apt-get update && apt-get install -y bluez bluetooth
 RUN pip3 install -U pip
 
 # initialize an empty remote git repository linked folder

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -107,10 +107,13 @@ def create_app(debug=False):
                             active_brew_sessions[uid].is_pico = mtype in [MachineType.PICOBREW, MachineType.PICOBREW_C]
 
     # optional Tilt monitoring
-    from .main import tilt
     if 'tilt_monitoring' in server_cfg and server_cfg['tilt_monitoring']:
-        sleep_interval = int(server_cfg['tilt_monitoring_interval']) if 'tilt_monitoring_interval' in server_cfg else 10
-        tiltThread = Thread(name='Tilt', target=tilt.run, daemon=True, args=(app, sleep_interval))
-        tiltThread.start()
+        try:
+            from .main import tilt
+            sleep_interval = int(server_cfg['tilt_monitoring_interval']) if 'tilt_monitoring_interval' in server_cfg else 10
+            tiltThread = Thread(name='Tilt', target=tilt.run, daemon=True, args=(app, sleep_interval))
+            tiltThread.start()
+        except Exception as e:
+            print(f"Error starting tilt thread. cause = {e}")
 
     return app


### PR DESCRIPTION
this catches any import failure (file/command `bluetoothctl` not found)