### PR TITLE
Fixed a couple of minor bugs

### DIFF
--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -262,11 +262,10 @@ def dirty_sessions_since_clean(uid):
     for s in brew_sessions:
         session_name = s.get('name')
         
-        if (session_name == "CLEAN" or session_name == "DEEP CLEAN"):
+        if (session_name.upper() in ["CLEAN", "DEEP CLEAN"]):
             clean_found = True
 
-
-        if (not clean_found and session_name not in ["RINSE", "CLEAN", "DEEP CLEAN", "RACK", "DRAIN"]):
+        if (not clean_found and session_name.upper() not in ["RINSE", "CLEAN", "DEEP CLEAN", "RACK", "DRAIN"]):
             post_clean_sessions.append(s)
 
     return len(post_clean_sessions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.25.0
 mock==4.0.3
 python-dateutil==2.8.1
 bleak==0.10.0
+eventlet==0.30.2


### PR DESCRIPTION
Fixed the identification of Deep Clean sessions for the Pico S/C/Pro. The session name is in mixed case from the name of the session json file, and is being compared to upper case session names. This results in a Deep Clean message whenever there are 3 or more sessions for the device, regardless of what they are. Making the comparison case insensitive fixes this.

Added [eventlet](https://eventlet.net) to the Python requirements.txt file in order to remove the warning message when starting the server. It appears to have no other effect on the operation of the server.