### PR TITLE
port proxy headers and config into http (c/s/pro/ferm/still)

### DIFF
--- a/scripts/pi/picobrew.com.conf
+++ b/scripts/pi/picobrew.com.conf
@@ -9,7 +9,11 @@ server {
         aio threads;
 
         proxy_set_header    Host $http_host;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
         proxy_pass          http://127.0.0.1:8080;
+        proxy_ignore_client_abort on;  # ignore client timeouts resulting in 499 error responses
     }
 
     location /socket.io {
@@ -22,8 +26,8 @@ server {
         include proxy_params;
         proxy_http_version 1.1;
         proxy_buffering off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header    Upgrade $http_upgrade;
+        proxy_set_header    Connection "Upgrade";
         proxy_pass http://127.0.0.1:8080/socket.io;
         proxy_ignore_client_abort on;  # ignore client timeouts resulting in 499 error responses
     }
@@ -63,5 +67,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_pass http://127.0.0.1:8080/socket.io;
+        proxy_ignore_client_abort on;  # ignore client timeouts resulting in 499 error responses
     }
 }


### PR DESCRIPTION
for some reason proxy headers and client timeout configuration was only added to https and not into http as well... fixing that with this change