### PR TITLE
setup initial embedded-ui, provide static way to add picostill.ip_address and better logging format and details

### DIFF
--- a/app/main/model.py
+++ b/app/main/model.py
@@ -110,22 +110,25 @@ class PicoStillSession:
 
     def start_still_polling(self):
         connect_failure = False
+        failure_message = None
+        still_data_uri = 'http://{}/data'.format(self.ip_address)
         try:
-            still_data_uri = 'http://{}/data'.format(self.ip_address)
             current_app.logger.debug('DEBUG: Retrieve PicoStill Data - {}'.format(still_data_uri))
             r = requests.get(still_data_uri)
             datastring = r.text.strip()
         except Exception as e:
-            current_app.logger.error(f'exception occured communicating to picostill : {e}')
+            current_app.logger.error(f'exception occured communicating to picostill {still_dataa_uri} : {e}')
+            failure_message = f'unable to estaablish successful connection to {still_data_uri}'
             datastring = None
             connect_failure = True
 
         if not datastring or datastring[0] != '#':
             connect_failure = True
-            current_app.logger.error(f'received unexpected response string : {datastring}')
+            failure_message = f'received unexpected response string from {still_data_uri}'
+            current_app.logger.error(f'{failure_message} : {datastring}')
 
         if connect_failure:
-            raise Exception('Connect PicoStill: Failed to connect to PicoStill on address \"' + self.ip_address + '\"')
+            raise Exception(f'Failed to Start PicoStill Monitoring: {failure_message}')
 
         from .still_polling import new_still_session
         from .still_polling import FlaskThread

--- a/app/main/model.py
+++ b/app/main/model.py
@@ -117,7 +117,7 @@ class PicoStillSession:
             r = requests.get(still_data_uri)
             datastring = r.text.strip()
         except Exception as e:
-            current_app.logger.error(f'exception occured communicating to picostill {still_dataa_uri} : {e}')
+            current_app.logger.error(f'exception occured communicating to picostill {still_data_uri} : {e}')
             failure_message = f'unable to estaablish successful connection to {still_data_uri}'
             datastring = None
             connect_failure = True

--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -29,6 +29,7 @@ def handle_devices():
         mtype = MachineType(request.form['machine_type'])
         uid = str(request.form['uid']).strip()
         alias = str(request.form['alias']).strip()
+        ip_addr = request.form['ip_addr'] if 'ip_addr' in request.form else None
 
         # uid and alias are required
         if len(uid) == 0 or len(alias) == 0:
@@ -87,6 +88,7 @@ def handle_devices():
             if uid not in active_still_sessions:
                 active_still_sessions[uid] = PicoStillSession(uid)
             active_still_sessions[uid].alias = alias
+            active_still_sessions[uid].ip_address = ip_addr
         elif mtype is MachineType.ISPINDEL:
             if uid not in active_iSpindel_sessions:
                 active_iSpindel_sessions[uid] = iSpindelSession()
@@ -117,6 +119,7 @@ def handle_specific_device(uid):
     # updated already registered device alias
     mtype = MachineType(request.form['machine_type'])
     alias = request.form['alias'] if 'alias' in request.form else ''
+    ip_addr = request.form['ip_addr'] if 'ip_addr' in request.form else None
 
     # verify uid is already configured
     if uid not in {**active_brew_sessions, **active_ferm_sessions, **active_iSpindel_sessions, **active_tilt_sessions, **active_still_sessions}:
@@ -157,6 +160,7 @@ def handle_specific_device(uid):
         active_ferm_sessions[uid].alias = alias
     elif mtype is MachineType.PICOSTILL:
         active_still_sessions[uid].alias = alias
+        active_still_sessions[uid].ip_address = ip_addr
     elif mtype is MachineType.ISPINDEL:
         active_iSpindel_sessions[uid].alias = alias
     elif mtype is MachineType.TILT:

--- a/app/main/routes_frontend.py
+++ b/app/main/routes_frontend.py
@@ -222,14 +222,14 @@ def update_device_session(uid, session_type):
                 try:
                     session.start_still_polling()
                 except Exception as e:
-                    current_app.logger.error('failed to start picostill polling thread')
+                    current_app.logger.error(f'exception occured : {e}')
                     return getattr(e, 'message', e.args[0]), 418
         
 
         return '', 204
     else:
         current_app.logger.error(f'invalid session type : {session_type}')
-        return 'Invalid session type provided \"' + session_type + '\"', 418
+        return f'Invalid session type provided {session_type}', 418
 
 
 ALLOWED_EXTENSIONS = {'json'}
@@ -597,7 +597,7 @@ def load_active_still_sessions():
     for uid in active_still_sessions:
         still_sessions.append({'alias': active_still_sessions[uid].alias,
                               'uid': uid,
-                              'ipaddr': active_still_sessions[uid].ip_address,
+                              'ip_address': active_still_sessions[uid].ip_address,
                               'active': active_still_sessions[uid].active,
                               'date': active_still_sessions[uid].created_at or None,
                               'graph': get_still_graph_data(uid, active_still_sessions[uid].name, active_still_sessions[uid].data)})

--- a/app/main/still_polling.py
+++ b/app/main/still_polling.py
@@ -3,7 +3,7 @@ import requests
 
 from .. import socketio
 from flask import current_app
-from .config import still_active_sessions_path
+from .config import still_active_sessions_path, server_cfg
 from .model import PicoStillSession
 from .session_parser import active_still_sessions
 
@@ -66,8 +66,6 @@ def poll_still(still_ip, uid):
 
 
 def new_still_session(still_ip, device_id):
-    global connection_failures
-
     connection_failures = 0
     uid = device_id
     if uid not in active_still_sessions or active_still_sessions[uid].uninit:
@@ -85,7 +83,9 @@ def new_still_session(still_ip, device_id):
             current_app.logger.debug("DEBUG: Connection failure {}".format(connection_failures))
         else:
             connection_failures = 0
-        sleep(60)
+
+        sleep_interval = int(server_cfg().get('still_monitoring_interval', 60))
+        sleep(sleep_interval)
 
     # If we've had 3 failures, clean up our session and end it.
     active_still_sessions[uid].file.write('\n]\n')

--- a/app/templates/devices.html
+++ b/app/templates/devices.html
@@ -6,6 +6,17 @@
   <script src="/static/js/highcharts/exporting.js"></script>
   <script src="/static/js/highcharts/dark-unica.js"></script>
   <script src="/static/js/devices.js"></script>
+  <script>
+    $(document).ready(function () {
+      $("#machine_type_new").change(function () {
+        var value = $("#machine_type_new option:selected").val();
+        if (value == "PicoStill") {
+          var ipAddrDiv = $("#ip_addr_entry")
+          ipAddrDiv.slideDown().toggleClass("d-none d-block")
+        }
+      });
+    });
+  </script>
   <div id="accordion">
     <div class="row bg-dark text-white-50">
       <div class="col-sm-12">
@@ -39,6 +50,11 @@
             <input type="text" class="form-control form-control-sm" name="alias" id="alias_new"
               placeholder="BrewHaus Alias" value="">
         </div>
+        <div id="ip_addr_entry" class="form-row form-group d-none">
+          <label for="ip_addr_new">IP Address</label>
+          <input type="text" class="form-control form-control-sm" name="ip_addr" id="ip_addr_new"
+            placeholder="192.168.72.108" value="">
+        </div>
         <div class="form-row form-group">
             <button type="submit" class="btn btn-primary">Save</button>
         </div>
@@ -59,10 +75,11 @@
       <p>No devices configured</p>
       {% else %}
       {% for uid in config['aliases'][machine_type] %}
+      {% set alias = config['aliases'][machine_type][uid] %}
       <div class="card bg-dark text-white-50">
         <h5 class="card-header" id="h_{{uid}}">
           <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{uid}}" data-parent="#accordion" aria-expanded="false" aria-controls="c_{{uid}}">
-            {{config['aliases'][machine_type][uid]}}
+            {{alias}}
             <button class="btn btn-sm btn-danger float-right mr-5" type="button" id="bdelete_{{uid}}"
                 onclick="event.stopPropagation();event.preventDefault();delete_device('{{machine_type}}', '{{uid}}');">
                 <i class="fas fa-trash"></i>
@@ -87,10 +104,19 @@
                 placeholder="Product ID (Username > Settings > Equipment)" value="{{uid}}" readonly>
           </div>
           <div class="form-row form-group">
-            <label for="alias_{{config['aliases'][machine_type][uid]}}">Alias</label>
-            <input type="text" class="form-control form-control-sm" name="alias" id="alias_{{config['aliases'][machine_type][uid]}}"
-                placeholder="BrewHaus Alias" value="{{config['aliases'][machine_type][uid]}}">
+            <label for="alias_{{uid}}">Alias</label>
+            <input type="text" class="form-control form-control-sm" name="alias" id="alias_{{uid}}"
+                placeholder="BrewHaus Alias" value="{{alias}}">
           </div>
+          {% if machine_type == 'PicoStill' %}
+          {% set active_session = active_sessions['still'][uid] %}
+          {% set ip_address = active_session.ip_address if active_session.ip_address != None and active_session.ip_address|length else "" %}
+          <div class="form-row form-group">
+            <label for="ip_addr_{{uid}}">IP Address</label>
+            <input type="text" class="form-control form-control-sm" name="ip_addr" id="ip_addr_{{uid}}"
+              placeholder="192.168.72.108" value="{{ip_address}}">
+          </div>
+          {% endif %}
           <div class="form-row form-group">
             <button type="submit" class="btn btn-primary">Save</button>
           </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -112,7 +112,7 @@
             <img src="/static/img/picostill.svg" atl="picostill" />
           </span>
           {% if still_session.alias is defined and still_session.alias|length %}{{still_session.alias}}{% else %}{{chart_id}}{% endif %}
-          {% if still_session.ipaddr %}
+          {% if still_session.ip_address %}
             <button class="still-start {{display_start}} btn btn-sm btn-success float-right mr-5" type="button" id="bstart_{{still_session.uid}}"
                 onclick="event.stopPropagation();event.preventDefault();start_monitoring('still', '{{still_session.uid}}');">
                 <i class="fas fa-play-circle"></i> Start Monitoring
@@ -129,7 +129,9 @@
           <div class="row">
             <div class="col-sm">
               <div class="text-white-50">Machine</div>
-              <div>{% if still_session.alias is defined and still_session.alias|length %}{{still_session.alias}} ({{still_session.uid}}){% else %}{{still_session.uid}}{% endif %}</div>
+              <div>
+                {% if still_session.alias is defined and still_session.alias|length %}{{still_session.alias}} ({{still_session.uid}}){% else %}{{still_session.uid}}{% endif %}
+              </div>
             </div>
             <div class="col-sm">
               {% if still_session.date %}
@@ -143,24 +145,27 @@
           <script>var graph_data={{still_session.graph|tojson}};</script>
           <script src="/static/js/still_graph_socketio.js"></script>
           
-          <!-- TODO (tmack) - the below only works in specific network setups (where your browsing device is on the same network...) -->
-          <!-- better setup would be to proxy all requests through the picobrew_pico service to the local IP address of the Still (according to the server) -->
-          <!-- going to work on this outside of the PicoStill graphing request -->
-
-          <!-- {% if still_session.ipaddr is defined and still_session.ipaddr != None and still_session.ipaddr|length%}
+          <!-- render an iframe of the embedded ui of the picostill -->
+          {% if still_session.ip_address %}
+          {% set ip = still_session.ip_address %}
           <div class="card bg-dark text-white-50">
             <h5 class="card-header" id="h2_{{chart_id}}">
               <a class="collapsed" role="button" data-toggle="collapse" href="#c2_{{chart_id}}" data-parent="#accordion" aria-expanded="{{expanded}}" aria-controls="c2_{{chart_id}}">
                 Embedded PicoStill UI (iframe)
-              </a>
             </h5>
             <div id="c2_{{chart_id}}" class="collapse show" aria-labelledby="h2_{{chart_id}}">
               <div class="card-body">
-                <iframe src="http://{{still_session.ipaddr}}/data-page"></iframe>
+                {% if platform is defined and platform == "RaspberryPi" %}
+                <a href="//embedded-content/data-page?ip={{ip}}">{{still_session.alias}}'s Data Page</a>
+                <iframe src="//embedded-content/data-page?ip={{ip}}" width="100%" height="500em"></iframe>
+                {% else %}
+                <a href="http://{{ip}}/data-page" target="_blank" rel="noopener noreferrer">{{still_session.alias}}'s Data Page</a>
+                <iframe src="http://{{ip}}/data-page" width="100%" height="500em"></iframe>
+                {% endif %}
               </div>
             </div>
           </div>
-          {% endif %} -->
+          {% endif %}
         </div>
       </div>
     </div>

--- a/scripts/docker/nginx/conf/picobrew.com.conf
+++ b/scripts/docker/nginx/conf/picobrew.com.conf
@@ -13,6 +13,12 @@ server {
         proxy_pass          http://app:8080;
     }
 
+    location /embedded-content {
+        if ( $arg_ip != "" ) {
+            proxy_pass http://$arg_ip$uri;
+        }
+    }
+
     location /socket.io {
         aio threads;
         
@@ -45,6 +51,12 @@ server {
         proxy_set_header    X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header    X-Forwarded-Proto \$scheme;
         proxy_pass          http://app:8080;
+    }
+
+    location /embedded-content {
+        if ( $arg_ip != "" ) {
+            proxy_pass http://$arg_ip$uri;
+        }
     }
     
     location /socket.io {

--- a/scripts/pi/00-run-chroot.sh
+++ b/scripts/pi/00-run-chroot.sh
@@ -142,7 +142,6 @@ cat > /etc/systemd/system/update_wpa_supplicant.service <<EOF
 [Unit]
 Description=Copy user wpa_supplicant.conf
 ConditionPathExists=/boot/wpa_supplicant.conf
-Before=ap-bring-up.service
 
 [Service]
 Type=oneshot
@@ -202,6 +201,7 @@ EOF
 
 echo 'Setting up dnsmasq...'
 cat >> /etc/dnsmasq.conf <<EOF
+domain=picobrew.local
 address=/picobrew.com/${AP_IP}
 address=/www.picobrew.com/${AP_IP}
 server=8.8.8.8


### PR DESCRIPTION
Having a manual way to add the ip_address actually makes it easier to setup for testing things. While this gives a way to fix things if say your pi or server turns off during a session (i did this while testing the integration).

--
random other change: 00-run-chroot.sh is a reference to a step that no longer exists and I also decided it was time to just name the local domain picobrew.local 😜 