### PR TITLE
Tilt Session Recovery from Power Loss Corruption

### DIFF
--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -50,6 +50,9 @@ def recover_incomplete_session(raw_data, filename):
     elif raw_data.endswith(','):
         # open trailing comma
         recovered_session = raw_data[:-1] + '\n]\n'
+    elif raw_data.endswith('\x00'):
+        # corrupted file (trailing nulls with open comma)
+        recovered_session = raw_data.rstrip("\x00")[:-1] + '\n]\n'
 
     return recovered_session
 


### PR DESCRIPTION
I found that after a power outage an active Tilt session would not load.  When the server was rebooted the session would show as active but no data was on the graph.

![image](https://user-images.githubusercontent.com/7861456/130798669-be668eda-e1b4-4510-a455-b3d09e00371e.png)

I found that this was due to NULL characters being at the end of the log file.

![image](https://user-images.githubusercontent.com/7861456/130798854-ceac87d1-93a9-4e16-a2ba-e33d8cecd3f4.png)

Since there was already a recover_incomplete_session function, to resolve this issue I added an endswith for NULL (\x00) which reverse strips them and fixes an open comma which recovers the session properly.

With this update a corrupted file is automatically recovered properly.

![image](https://user-images.githubusercontent.com/7861456/130799558-67c4cb2f-1966-427c-ae9f-b7cecf033edf.png)

Here is a example of a corrupted session file.  It has been renamed from .json to .txt so I could upload it.
[20210807_164541#Orange-C71885D66A9C.txt](https://github.com/chiefwigms/picobrew_pico/files/7047325/20210807_164541.Orange-C71885D66A9C.txt)