### PR TITLE
Combine a few sessions into UTILITY and fix DEEP CLEAN

### DIFF
--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -610,7 +610,7 @@ class ZProgramId(int, Enum):
     RINSE = 1
     DRAIN = 2
     RACK_BEER = 3
-    CIRRCULATE = 4
+    CIRCULATE = 4
     SOUS_VIDE = 6
     CLEAN = 12
     BEER_OR_COFFEE = 24

--- a/app/main/session_parser.py
+++ b/app/main/session_parser.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from dateutil import tz
 from enum import Enum
+from aenum import MultiValueEnum
 from pathlib import Path
 from flask import current_app
 
@@ -17,6 +18,8 @@ active_ferm_sessions = {}
 active_still_sessions = {}
 active_iSpindel_sessions = {}
 active_tilt_sessions = {}
+
+invalid_sessions = {}
 
 
 def load_session_file(filename):
@@ -615,28 +618,30 @@ class ZProgramId(int, Enum):
     CHILL = 27
 
 
-class PicoSessionType(str, Enum):
+class PicoSessionType(str, MultiValueEnum):
     RINSE = "RINSE"
-    CLEAN = "CLEAN"
-    DEEP_CLEAN = "DEEP CLEAN"
+    CLEAN = "CLEAN", "DEEP_CLEAN", "DEEP CLEAN"
     DRAIN = "DRAIN"
     RACK_BEER = "RACK"
     MANUAL = "MANUAL"
     BEER = "BEER"
 
+    @classmethod
+    def _missing_value_(cls, value):
+        for member in cls:
+            for _value in member._values_:
+                if _value.lower() == value.lower():
+                    return member
 
-class BrewSessionType(str, Enum):
+
+class BrewSessionType(str, MultiValueEnum):
     RINSE = "RINSE"
-    CLEAN = "CLEAN"
-    DRAIN = "DRAIN"
-    RACK_BEER = "RACK_BEER"
+    CLEAN = "CLEAN",
+    UTILITY = "RACK_BEER", "RACK BEER", "CIRCULATE", "CHILL", "SOUS_VIDE", "SOUS VIDE", "DRAIN"
     MANUAL = "MANUAL"
     BEER = "BEER"
-    CIRCULATE = "CIRCULATE"
-    SOUS_VIDE = "SOUS VIDE"
     STILL = "STILL"
     COFFEE = "COFFEE"
-    CHILL = "CHILL"
 
 
 def dirty_sessions_since_clean(uid, mtype):
@@ -692,7 +697,8 @@ def last_session_metadata(uid, mtype):
             try:
                 stype = PicoSessionType(sname)
             except Exception as err:
-                stype = PicoSessionType("BEER")  # pico only has name in file (no type enum)
+                current_app.logger.warn("unknown session type {} - {}".format(sname, err))
+                stype = PicoSessionType.BEER  # pico only has name in file (no type enum)
             return stype, sname
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -56,9 +56,11 @@
             {% endif %}
             {% if brew_session.last_session %}
               <div class="col-sm">
-                {% set badge_color = "primary" %}
+                {% set badge_color = "blue" %} <!-- warning (yellow) == dirty session; success (green) == clean; primary (blue) == non-dirty session -->
                 {% if brew_session.last_session.type == "CLEAN" or brew_session.last_session.type == "RINSE" or brew_session.last_session.type == "STILL" or brew_session.last_session.type == "DEEP CLEAN" %}
                 {% set badge_color = "success" %}
+                {% elif brew_session.last_session.type == "BEER" or brew_session.last_session.type == "COFFEE" or brew_session.last_session.type == "MANUAL" or brew_session.last_session.type == "COFFEE" or brew_session.last_session.name.lower() == "rack" %}
+                {% set badge_color = "warning" %}
                 {% endif %}
                 <div class="text-white-50">Last Session <span class="badge badge-{{badge_color}} ml-2">{{brew_session.last_session.type}}</span></div>
                 <div>{{brew_session.last_session.name}}</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -60,7 +60,7 @@
                 {% if brew_session.last_session.type == "CLEAN" or brew_session.last_session.type == "DEEP CLEAN" %}
                 {% set badge_color = "success" %}
                 {% elif brew_session.last_session.type == "RINSE" or brew_session.last_session.type == "STILL" %}
-                {% set badge_color = "blue" %}
+                {% set badge_color = "primary" %}
                 {% endif %}
                 <div class="text-white-50">Last Session <span class="badge badge-{{badge_color}} ml-2">{{brew_session.last_session.type}}</span></div>
                 <div>{{brew_session.last_session.name}}</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -56,11 +56,11 @@
             {% endif %}
             {% if brew_session.last_session %}
               <div class="col-sm">
-                {% set badge_color = "blue" %} <!-- warning (yellow) == dirty session; success (green) == clean; primary (blue) == non-dirty session -->
-                {% if brew_session.last_session.type == "CLEAN" or brew_session.last_session.type == "RINSE" or brew_session.last_session.type == "STILL" or brew_session.last_session.type == "DEEP CLEAN" %}
+                {% set badge_color = "warning" %} <!-- warning (yellow) == dirty session; success (green) == clean; primary (blue) == non-dirty session -->
+                {% if brew_session.last_session.type == "CLEAN" or brew_session.last_session.type == "DEEP CLEAN" %}
                 {% set badge_color = "success" %}
-                {% elif brew_session.last_session.type == "BEER" or brew_session.last_session.type == "COFFEE" or brew_session.last_session.type == "MANUAL" or brew_session.last_session.type == "COFFEE" or brew_session.last_session.name.lower() == "rack" %}
-                {% set badge_color = "warning" %}
+                {% elif brew_session.last_session.type == "RINSE" or brew_session.last_session.type == "STILL" %}
+                {% set badge_color = "blue" %}
                 {% endif %}
                 <div class="text-white-50">Last Session <span class="badge badge-{{badge_color}} ml-2">{{brew_session.last_session.type}}</span></div>
                 <div>{{brew_session.last_session.name}}</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mock==4.0.3
 python-dateutil==2.8.1
 bleak==0.10.0
 eventlet==0.31.0
+aenum==3.1.2


### PR DESCRIPTION
To get more utility (pun intended) out of the last session "type" and "name" decided to go and collapse a bunch into "UTILITY" and also mark "Deep Clean" as the same a "Clean" cause after all it is a clean session type.

Before:
![image](https://user-images.githubusercontent.com/2158627/139968155-b52943c8-c8ae-4c74-bf4b-d4885dcf4948.png)

After (showing the color status meaning):
![image](https://user-images.githubusercontent.com/2158627/139968220-f98ae7e6-796b-4639-8e11-fa1ba6e460bd.png)
![image](https://user-images.githubusercontent.com/2158627/139968243-5079e60d-489e-40c2-bea7-975d593dc964.png)
![image](https://user-images.githubusercontent.com/2158627/139968343-50c7d903-e36b-431a-a35e-061f5da7041a.png)


Fixed a bug I introduced in invalid_sessions not being defined at the global state... 🐞 