### PR TITLE
fix tilt pro resolution issue

### DIFF
--- a/app/main/routes_tilt_api.py
+++ b/app/main/routes_tilt_api.py
@@ -60,12 +60,24 @@ def process_tilt_data(data):
             time = (datetime.fromisoformat(data['timestamp']) - datetime(1970, 1, 1)).total_seconds() * 1000
             session_data = []
             log_data = ''
+            
             point = {
                 'time': time,
-                'temp': data['temp'],
-                'gravity': data['gravity'] / 1000,
                 'rssi': data['rssi'],
             }
+            
+            if data['gravity'] > 2000:
+                point.update({
+                    'temp': data['temp'] / 10,
+                    'gravity': data['gravity'] / 10000,
+                    'resolution': 'high'
+                })
+            else:
+                point.update({
+                    'temp': data['temp'],
+                    'gravity': data['gravity'] / 1000,
+                    'resolution': 'low'
+                })
 
             session_data.append(point)
             log_data += '\n\t{},'.format(json.dumps(point))

--- a/app/main/tilt.py
+++ b/app/main/tilt.py
@@ -63,7 +63,7 @@ def tilts(devices):
                         'color': color,
                         'timestamp': datetime.utcnow().isoformat(),
                         'temp': get_number(data[18:20]),     # fahrenheit
-                        'gravity': get_number(data[20:22]),  # gravity * 1000
+                        'gravity': get_number(data[20:22]),  # gravity * 1000; or gravity * 10000 (pro)
                     })
     return tilts
 

--- a/scripts/python/scan_tilt.py
+++ b/scripts/python/scan_tilt.py
@@ -46,17 +46,26 @@ async def run():
             #print(d)
             if d.metadata['manufacturer_data'] and 76 in d.metadata['manufacturer_data']:
                 data = d.metadata['manufacturer_data'][76]
-                #print(get_string(data))
+                # print(get_string(data))
                 if bytearray(data[:2]) == bytearray(IBEACON_PROXIMITY_TYPE):
                     uuid=get_string(data[2:18])
                     if uuid in TILTS:
                         color = TILTS[uuid]
                         temp=get_number(data[18:20]) # farenheight
-                        gravity=get_number(data[20:22]) # gravity * 1000
+                        gravity=get_number(data[20:22]) # gravity * 1000; gravity * 10000 (pro)
                         tx_power=get_number(data[22:23])
                         rssi=get_rssi(data[22:23])
-                        print("uuid: {} color: {} temp: {} gravity: {} rssi: {} tx_power: {}".format(
-                                    uuid,     color,   temp,      gravity,  rssi,    tx_power))
+
+                        if gravity > 1000:
+                            # tilt pro has 1 more digit of resolution for both temp and gravity readings
+                            gravity = gravity / 10
+                            temp = temp / 10
+                            resolution = 'high'
+                        else:
+                            resolution = 'low'
+
+                        print("uuid: {} color: {} temp: {} gravity: {} rssi: {} tx_power: {} resolution: {}".format(
+                                    uuid,     color,   temp,      gravity,  rssi,      tx_power,     resolution))
         time.sleep(10)
 
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
The tilt pro has 1 more decimal place for both temp and gravity readings that weren't measuring right on pytilt (the python script we started from) nor in our application. This fixes that by dividing both (non decimals) by an additional 10.

![image](https://user-images.githubusercontent.com/2158627/141206017-109c7e95-d735-4fcf-9837-0a0170a99b9c.png)
