### PR TITLE
Issue #138 - include a backup recipe and session file capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@ config.yaml
 
 # ignore all machine_type recipe and session files
 app/recipes/*/*
+app/recipes/*.zip
 app/sessions/*/active/*
 app/sessions/*/archive/*
+app/sessions/*.zip
 
 scripts/docker/nginx/certs/*
 

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -55,22 +55,37 @@ def firmware_path(machineType):
         raise Exception("firmware_path: unsupported machine type {machineType}")
 
 
-# recipe paths
+# recipe path
 def recipe_path(machineType, archived=False):
-    recipe_filepath = ""
+    filepath = current_app.config['RECIPES_PATH']
     if machineType is MachineType.PICOBREW or machineType is MachineType.PICOBREW_C:
-        recipe_filepath = current_app.config['RECIPES_PATH'].joinpath('pico')
+        filepath = filepath.joinpath('pico')
     elif machineType is MachineType.ZYMATIC:
-        recipe_filepath = current_app.config['RECIPES_PATH'].joinpath('zymatic')
+        filepath = filepath.joinpath('zymatic')
     elif machineType is MachineType.ZSERIES:
-        recipe_filepath = current_app.config['RECIPES_PATH'].joinpath('zseries')
+        filepath = filepath.joinpath('zseries')
     else:
         raise Exception("recipe_path: unsupported machine type {machineType}")
 
     if archived:
-        recipe_filepath = recipe_filepath.joinpath('archive')
+        filepath = filepath.joinpath('archive')
 
-    return recipe_filepath
+    return filepath
+
+
+# session path
+def session_path(sessionType, archived=False):
+    try:
+        filepath = current_app.config['SESSIONS_PATH'].joinpath(SessionType(sessionType))
+    except:
+        raise Exception("session_path: unsupported session type {sessionType}")
+
+    if archived:
+        filepath = filepath.joinpath('archive')
+    else:
+        filepath = filepath.joinpath('active')
+
+    return filepath
 
 
 # sessions paths

--- a/app/main/routes_server.py
+++ b/app/main/routes_server.py
@@ -324,7 +324,7 @@ def backup_recipes(directory):
         zip_directory(f"{filepath}/{directory}", filepath)
     elif directory == "sessions":
         filepath = str(current_app.config['SESSIONS_PATH'])
-        zip_directory(f"{filepath}/{directory}", str(current_app.config['SESSIONS_PATH']))
+        zip_directory(f"{filepath}/{directory}", filepath)
     else:
         return 400, f"{directory} not supported for backing up"
 


### PR DESCRIPTION
Haven't exposed to the UI, but for now folks that want to backup their recipe and session files without using samba... can do so from `http://<ip-hostname>/backup/recipes` and `http://<ip-hostname>/backup/sessions` which will appropriately zip up the existing `app/recipes` and `app/sessions` folders respectfully and provide the resulting file as a download.

I've also found that `send_file()` has arguments to setup no-cache headers and the correct "download as file" headers so no need to create a manual response structure with headers instead leveraging the optional arguments of `send_file()`.

![image](https://user-images.githubusercontent.com/2158627/158289830-937ea0d7-bdce-4db2-86b4-900a0d32135b.png)
![image](https://user-images.githubusercontent.com/2158627/158289841-5549a873-549e-494f-bdcd-b40ba76ae79c.png)


![image](https://user-images.githubusercontent.com/2158627/158289858-d1fe295d-5a24-4c48-8ae9-07efbbeed6c0.png)
![image](https://user-images.githubusercontent.com/2158627/158289867-23aa6169-2929-4dde-94c7-f492ab0e7226.png)