### PR TITLE
Random fixes - New Device Firmware Failing to Loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,8 @@ config.yaml
 
 # ignore all machine_type recipe and session files
 app/recipes/*/*
+app/sessions/*/*/*
 app/recipes/*.zip
-app/sessions/*/active/*
-app/sessions/*/archive/*
 app/sessions/*.zip
 
 scripts/docker/nginx/certs/*

--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -123,6 +123,7 @@ def handle_devices():
         else:
             if uid not in active_brew_sessions:
                 active_brew_sessions[uid] = PicoBrewSession(mtype)
+            active_brew_sessions[uid].machine_type = mtype
             active_brew_sessions[uid].is_pico = True if mtype in [MachineType.PICOBREW, MachineType.PICOBREW_C] else False
             active_brew_sessions[uid].alias = alias
 

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -77,8 +77,9 @@ get_firmware_args = {
 @main.route('/API/pico/getFirmware')
 @use_args(get_firmware_args, location='querystring')
 def process_get_firmware(args):
-    if args['uid'] in active_brew_sessions:
-        machine_type = active_brew_sessions[args['uid']].machine_type
+    uid = args['uid']
+    if uid in active_brew_sessions and active_brew_sessions[uid].machine_type is not None:
+        machine_type = active_brew_sessions[uid].machine_type
         filename = firmware_filename(machine_type, minimum_firmware(machine_type))
         f = open(firmware_path(machine_type).joinpath(filename))
         fw = f.read()
@@ -107,7 +108,7 @@ def process_get_actions_needed(args):
 #    Error: /API/pico/error?uid={UID}&rfid={RFID}
 # Response: '\r\n'
 error_args = {
-    'uid': fields.Str(required=True),       # 32 character alpha-numeric serial number
+    'uid': fields.Str(required=True),        # 32 character alpha-numeric serial number
     'code': fields.Str(required=True),       # Integer error number
     'rfid': fields.Str(required=False),      # 14 character alpha-numeric PicoPak RFID (could be blank)
 }

--- a/app/main/routes_pico_api.py
+++ b/app/main/routes_pico_api.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 from datetime import datetime
+from flask import current_app
 from webargs import fields
 from webargs.flaskparser import use_args, FlaskParser
 
@@ -86,6 +87,7 @@ def process_get_firmware(args):
         f.close()
         return '{}'.format(fw)
     else:
+        current_app.logger.warn('machine_type unknown - can not fetch firmware. Configuration of the device type via /devices UX is required.')
         # TODO: Error Processing?
         return '#F#'
 


### PR DESCRIPTION
There was a thread between Diane, Kevin and myself on Facebook that a factory reset C was failing to load firmware.

In this situation here are the only requests made to the server from the device:
```
192.168.72.183 - - [25/Jan/2021:14:43:31 -0500] "GET /API/pico/error?uid=<uid>&code=17 HTTP/1.0" 499 0 "-" "-"
192.168.72.183 - - [25/Jan/2021:14:43:53 -0500] "GET /API/pico/register?uid=<uid> HTTP/1.0" 200 5 "-" "-"
192.168.72.183 - - [25/Jan/2021:14:44:00 -0500] "GET /API/pico/getFirmware?uid=<uid> HTTP/1.0" 500 290 "-" "-"
```

without the proceeding request to `GET /API/pico/checkFirmware?uid=<uid>` which has been seen before in practice. This is likely due to the firmware being factory reset to knowing somehow that the firmware already needs to be updated? Only happens when the `machine_type` isn't known to the server. Upon adding an alias via the UI I noticed that the `mtype` wasn't being modified if there was previous active sessions against the specific `uid` being aliased. Here I'm persisting whichever `mtype` the user selected in the UI (which is where the alias is added to the config.yaml and will be loaded from upon server restart().