### PR TITLE
Include a ZBackendError for BoilerType Mismatch

### DIFF
--- a/app/main/model.py
+++ b/app/main/model.py
@@ -60,6 +60,7 @@ class PicoBrewSession:
         self.recovery = ''
         self.remaining_time = None
         self.is_pico = True if machineType in [MachineType.PICOBREW, MachineType.PICOBREW_C] else False
+        self.boiler_type = None   # Z machines have 2 different configurations: 1 (big) or 2 (small)
         self.data = []
 
     def cleanup(self):


### PR DESCRIPTION
This technically could still get into the **Error 5: TOO COLD** state by having the Z report the wrong boiler type for the first ZState request sent to the server. Without mucking with config and other stuff users would have to actually know their boiler type... so figured this was good enough to get that more helpful error than to cause more confusion about "my Z says too cold... what do I do now?" type inquiries.