### PR TITLE
Remove Github Action "Deployment" from PR triggered builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,32 @@ on:
     branches: [ master ]
 
 jobs:
-  docker:
+  build:
+    if: github.ref != 'ref/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@master
+      with:
+        platforms: all
+    
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+
+    - name: Build Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        tags: ${{ steps.prep.outputs.tags }}
+
+  build-push:
+    if: github.ref == 'ref/heads/master'
     environment: picobrew-server
     runs-on: ubuntu-latest
     steps:
@@ -47,25 +72,13 @@ jobs:
       uses: docker/setup-buildx-action@master
     
     - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build Docker Image
-      uses: docker/build-push-action@v3
-      if: ${{ github.ref != 'ref/heads/main' }}
-      with:
-        builder: ${{ steps.buildx.outputs.name }}
-        context: .
-        file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
-        tags: ${{ steps.prep.outputs.tags }}
-
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v3
-      if: ${{ github.ref == 'ref/heads/main' }}
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: .

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python Application
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PORT=80
 WORKDIR /picobrew_pico
 
 RUN apt-get update && \
-    apt-get install -y bluez bluetooth git gcc && \
+    apt-get install -y bluez bluetooth git gcc g++ && \
     apt-get clean
 
 RUN pip3 install -U pip


### PR DESCRIPTION
- include g++ in installed operating system packages (required by dependency)
- rename and restructure github actions to not "deploy" in a PR