### PR TITLE
adding missing folders to init

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,14 +60,16 @@ def create_app(debug=False):
     )
 
     # create subdirectories if they don't already exist
-    create_dir(app.config['RECIPES_PATH'].joinpath('pico'))
-    create_dir(app.config['RECIPES_PATH'].joinpath('zymatic'))
+    create_dir(app.config['RECIPES_PATH'].joinpath('pico/archive'))
+    create_dir(app.config['RECIPES_PATH'].joinpath('zymatic/archive'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('brew/active'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('brew/archive'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('ferm/active'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('ferm/archive'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('iSpindel/active'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('iSpindel/archive'))
+    create_dir(app.config['SESSIONS_PATH'].joinpath('still/active'))
+    create_dir(app.config['SESSIONS_PATH'].joinpath('still/archive'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('tilt/active'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('tilt/archive'))
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,6 +61,7 @@ def create_app(debug=False):
 
     # create subdirectories if they don't already exist
     create_dir(app.config['RECIPES_PATH'].joinpath('pico/archive'))
+    create_dir(app.config['RECIPES_PATH'].joinpath('zseries/archive'))
     create_dir(app.config['RECIPES_PATH'].joinpath('zymatic/archive'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('brew/active'))
     create_dir(app.config['SESSIONS_PATH'].joinpath('brew/archive'))


### PR DESCRIPTION
I ran into an issue in my environment where I hadn’t pre-populated the folders within the mounted volumes and things *mostly* worked correctly until I couldn’t start a brew session.  Adding the recipes/pico/archive folder manually fixed the issue, so adding those to the init set of folders to create.