### PR TITLE
Deprecated Tabulator Fix and Improve Error Handling

### DIFF
--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -135,7 +135,6 @@ def handle_devices():
     # merge PicoBrewC_Alt and PicoBrewC for /devices experience
     merged_config = server_config()
     if 'PicoBrewC_Alt' in merged_config['aliases']:
-        pico_c_alt = None
         pico_c_alt = merged_config['aliases']['PicoBrewC_Alt']
         # skip merging if PicoBrewC_Alt is empty or not defined
         if pico_c_alt:

--- a/app/main/routes_devices.py
+++ b/app/main/routes_devices.py
@@ -185,9 +185,7 @@ def handle_specific_device(uid):
             # delete uid entry from either PicoBrew C config (alternate or normal)
             if mtype in [MachineType.PICOBREW_C, MachineType.PICOBREW_C_ALT]:
                 for type in [MachineType.PICOBREW_C, MachineType.PICOBREW_C_ALT]:
-                    current_app.logger.error(f"type:%s mtype:%s", type, mtype)
                     if type in new_server_cfg['aliases'] and uid in new_server_cfg['aliases'][type]:
-                        current_app.logger.error(f"found uid: %s", uid)
                         del new_server_cfg['aliases'][type][uid]
 
             if request.method == 'POST':

--- a/app/static/js/base_recipe.js
+++ b/app/static/js/base_recipe.js
@@ -222,3 +222,18 @@ function recipe_tooltips(machine_type) {
         return tip;
     }
 }
+
+$(document).ready(function () {
+    // recipe metadata toggles unsaved state
+    for (element of document.getElementsByClassName("recipe")) {
+        const rId = element.dataset.recipeId
+        $(`#f_${rId} textarea`).bind('input propertychange', () => displayUnsavedState(rId));
+        $(`#f_${rId} input[type=text]`).bind('input propertychange', () => displayUnsavedState(rId));
+
+        // show error/alert if there are multiple recipes with the same matching id
+        const duplicatedIds = document.querySelectorAll(`#c_${rId}`)
+        if (duplicatedIds.length > 1) {
+            showAlert(`Error: ${duplicatedIds.length} recipes found with same id:${rId}`, "danger");
+        }
+    }
+})

--- a/app/static/js/pico_recipe.js
+++ b/app/static/js/pico_recipe.js
@@ -20,7 +20,6 @@ var idMutator = function (value, data, type, params, component) {
 var recipe_table = {
     movableRows: true,
     layout: "fitDataFill",
-    tooltipGenerationMode: "hover",
     columnDefaults:{
         headerSort: false,
         hozAlign: "center",

--- a/app/static/js/zseries_recipe.js
+++ b/app/static/js/zseries_recipe.js
@@ -25,7 +25,6 @@ var default_data = [
 var recipe_table = {
     movableRows: true,
     layout: "fitDataFill",
-    tooltipGenerationMode: "hover",
     columnDefaults:{
         headerSort: false,
         hozAlign: "center",

--- a/app/static/js/zymatic_recipe.js
+++ b/app/static/js/zymatic_recipe.js
@@ -20,7 +20,6 @@ var default_data = [
 var recipe_table = {
     movableRows: true,
     layout: "fitDataFill",
-    tooltipGenerationMode: "hover",
     columnDefaults:{
         headerSort: false,
         hozAlign: "center",

--- a/app/templates/recipe_list.html
+++ b/app/templates/recipe_list.html
@@ -24,7 +24,7 @@
 </script>
 <div id="accordion">
     {% for recipe in recipes %}
-    <div class="card bg-dark text-white-50">
+    <div class="card bg-dark text-white-50 recipe" data-recipe-id="{{recipe['id']}}">
         <h5 class="card-header" id="h_{{recipe['id']}}">
             <a class="collapsed" role="button" data-toggle="collapse" href="#c_{{recipe['id']}}"
                 data-toggle="tooltip" data-placement="bottom" title="Expand to See Recipe Details"
@@ -150,12 +150,8 @@
                 </div>
                 <script>
                     var recipe_id = "{{recipe['id']}}"
-                    // recipe metadata toggles unsaved state
-                    $(`#f_${recipe_id} textarea`).bind('input propertychange', () => displayUnsavedState(recipe_id))
-                    $(`#f_${recipe_id} input[type=text]`).bind('input propertychange', () => displayUnsavedState(recipe_id))
 
                     recipe_table['data'] = {{ recipe['steps']| tojson }};
-
                     tables[recipe_id] = new Tabulator(`#t_${recipe_id}`, recipe_table);
 
                     subscribe_table_callbacks(tables[recipe_id]);


### PR DESCRIPTION
fix deprecated tabulator use of tooltips and include centralized edit/save detection logic (opposed to <script> tags everywhere) and raise alert flag when duplicated recipe.id are found

<img width="1697" alt="image" src="https://github.com/chiefwigms/picobrew_pico/assets/2158627/321ca802-5409-442f-a4a3-f0b6eca85850">

example alert flag for duplicated recipe.id found
<img width="1385" alt="image" src="https://github.com/chiefwigms/picobrew_pico/assets/2158627/292d4e49-4a8b-495d-b27b-5503db369827">

